### PR TITLE
feat: add selectable Quartz theme presets

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,84 @@
+# dg3 Design System
+
+## 1. Atmosphere & Identity
+
+This digital garden should feel like a quiet reading desk for technical notes, source tracking, and long-term thinking. The signature is restrained notebook depth: high-contrast text, muted surfaces, and one calm accent per theme so links and graph affordances remain clear without making the reading surface decorative.
+
+## 2. Color
+
+Quartz exposes nine color roles per mode through `quartz/util/theme.ts`. Six named presets live in `quartz/util/themePresets.ts`; each preset supplies both `lightMode` and `darkMode`, and Quartz still toggles only `saved-theme="light"` or `saved-theme="dark"` at runtime.
+
+Set the build-time preset with `QUARTZ_THEME=<preset>`. When `QUARTZ_THEME` is unset, Quartz uses the `theme` object in `quartz.config.yaml`, which is the `oldwinter` preset for this garden.
+
+### Presets
+
+| Preset      | Intent                                                                  |
+| ----------- | ----------------------------------------------------------------------- |
+| `oldwinter` | Default warm-neutral garden palette with blue-green navigation accents. |
+| `ink`       | Paper-and-ink reading palette with olive and clay accents.              |
+| `mist`      | Cool mist palette for soft cyan-green links and quiet diagrams.         |
+| `ember`     | Warm ember palette for a more editorial, earthy reading tone.           |
+| `atlas`     | Crisp atlas palette with blue structural accents and brass highlights.  |
+| `sakura`    | Soft rose palette balanced by teal secondary accents.                   |
+
+### Rules
+
+- Do not add extra CSS variable names for theme colors unless Quartz core needs a new semantic role.
+- Keep body text, headings, links, and hover accents readable in both modes.
+- Runtime dark mode remains the existing `saved-theme` light/dark toggle.
+- Theme presets affect color and typography only; layout and component structure should stay Quartz-native.
+
+## 3. Typography
+
+| Level   | Size       | Weight | Line Height | Tracking | Usage         |
+| ------- | ---------- | ------ | ----------- | -------- | ------------- |
+| H1      | `2rem`     | 700    | 1.2         | 0        | Article title |
+| H2      | `1.75rem`  | 700    | 1.25        | 0        | Major section |
+| H3      | `1.4rem`   | 600    | 1.3         | 0        | Subsection    |
+| Body    | `1rem`     | 400    | 1.6         | 0        | Default prose |
+| Body/sm | `0.875rem` | 400    | 1.5         | 0        | Metadata      |
+| Code    | `0.9rem`   | 400    | 1.5         | 0        | Code          |
+
+Theme presets use:
+
+- Header: `Schibsted Grotesk`, then system sans-serif.
+- Body: `LXGW WenKai`, then system sans-serif for CJK-friendly reading.
+- Code: `IBM Plex Mono`, then system monospace.
+
+## 4. Spacing & Layout
+
+Spacing follows Quartz defaults and a 4px base unit. New spacing should remain a 4px multiple. Keep prose width constrained by Quartz frames, and keep sidebars resilient to long CJK and English note titles.
+
+## 5. Components
+
+### Theme Presets
+
+- **Structure**: named TypeScript registry in `quartz/util/themePresets.ts`.
+- **Variants**: `oldwinter`, `ink`, `mist`, `ember`, `atlas`, `sakura`.
+- **Selection**: `QUARTZ_THEME=<preset>` at build time, or `quartz.config.yaml` when unset.
+- **States**: light and dark mode are both required for every preset.
+- **Accessibility**: body text, heading text, link text, and hover text must keep readable contrast on `--light`.
+
+### Dark Mode Toggle
+
+- **Structure**: existing `github:quartz-community/darkmode` plugin.
+- **Variants**: light mode and dark mode icons.
+- **States**: hover, click, and persisted localStorage state.
+- **Accessibility**: icon titles and aria labels come from i18n strings.
+
+## 6. Motion & Interaction
+
+Theme-adjacent UI uses existing Quartz transitions. Only animate `transform`, `opacity`, `fill`, or `color`; do not animate layout dimensions for theme changes.
+
+## 7. Depth & Surface
+
+Quartz uses restrained tonal shifts through `--light` and `--lightgray`, with borders for popovers, graph controls, code blocks, tables, and callouts.
+
+| Type           | Value                        | Usage                              |
+| -------------- | ---------------------------- | ---------------------------------- |
+| Default border | `1px solid var(--lightgray)` | Controls, panels, popovers         |
+| Accent rule    | `3px solid var(--secondary)` | Blockquotes and highlighted blocks |
+| Surface fill   | `var(--light)`               | Main and elevated surfaces         |
+| Subtle fill    | `var(--highlight)`           | Internal links and selected text   |
+
+Do not introduce broad box-shadow styling for theme presets; Quartz should remain quiet and text-first.

--- a/quartz.config.yaml
+++ b/quartz.config.yaml
@@ -27,25 +27,25 @@ configuration:
       code: IBM Plex Mono
     colors:
       lightMode:
-        light: "#faf8f8"
-        lightgray: "#e5e5e5"
-        gray: "#b8b8b8"
-        darkgray: "#4e4e4e"
-        dark: "#2b2b2b"
-        secondary: "#284b63"
-        tertiary: "#84a59d"
+        light: "#faf8f7"
+        lightgray: "#e6e0dd"
+        gray: "#817671"
+        darkgray: "#4b4542"
+        dark: "#24211f"
+        secondary: "#28546a"
+        tertiary: "#4f785f"
         highlight: rgba(143, 159, 169, 0.15)
         textHighlight: "#fff23688"
       darkMode:
-        light: "#161618"
-        lightgray: "#393639"
-        gray: "#646464"
-        darkgray: "#d4d4d4"
-        dark: "#ebebec"
-        secondary: "#7b97aa"
-        tertiary: "#84a59d"
+        light: "#151716"
+        lightgray: "#2d3430"
+        gray: "#87938c"
+        darkgray: "#d3d8d2"
+        dark: "#f3f0ea"
+        secondary: "#8ab2c4"
+        tertiary: "#9dbb91"
         highlight: rgba(143, 159, 169, 0.15)
-        textHighlight: "#fff23688"
+        textHighlight: "#b3aa0288"
 
 plugins:
   - source: github:quartz-community/note-properties

--- a/quartz.ts
+++ b/quartz.ts
@@ -1,5 +1,7 @@
 import { loadQuartzConfig, loadQuartzLayout } from "./quartz/plugins/loader/config-loader"
+import { getThemePresetFromEnvironment } from "./quartz/util/themePresets"
 
-const config = await loadQuartzConfig()
+const selectedTheme = getThemePresetFromEnvironment(process.env)
+const config = await loadQuartzConfig(selectedTheme ? { theme: selectedTheme } : undefined)
 export default config
 export const layout = await loadQuartzLayout()

--- a/quartz/util/themePresets.test.ts
+++ b/quartz/util/themePresets.test.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert"
+import test, { describe } from "node:test"
+import { joinStyles } from "./theme"
+import {
+  getThemePreset,
+  getThemePresetFromEnvironment,
+  quartzThemePresets,
+  themePresetNames,
+  UnknownThemePresetError,
+} from "./themePresets"
+
+describe("theme presets", () => {
+  test("defines six complete light and dark Quartz theme sets", () => {
+    assert.strictEqual(themePresetNames.length, 6)
+
+    for (const name of themePresetNames) {
+      const preset = getThemePreset(name)
+      for (const mode of ["lightMode", "darkMode"] as const) {
+        assert.deepStrictEqual(Object.keys(preset.colors[mode]).sort(), [
+          "dark",
+          "darkgray",
+          "gray",
+          "highlight",
+          "light",
+          "lightgray",
+          "secondary",
+          "tertiary",
+          "textHighlight",
+        ])
+      }
+    }
+  })
+
+  test("keeps oldwinter compatible with the existing CSS variable contract", () => {
+    const css = joinStyles(quartzThemePresets.oldwinter, "")
+
+    assert(css.includes(":root {"))
+    assert(css.includes(':root[saved-theme="dark"] {'))
+    assert(css.includes("--light: #faf8f7;"))
+    assert(css.includes("--secondary: #28546a;"))
+    assert(css.includes("--light: #151716;"))
+    assert(css.includes("--secondary: #8ab2c4;"))
+  })
+
+  test("resolves a named theme preset from QUARTZ_THEME", () => {
+    const preset = getThemePresetFromEnvironment({ QUARTZ_THEME: "sakura" })
+
+    assert.strictEqual(preset, quartzThemePresets.sakura)
+  })
+
+  test("leaves the YAML theme active when QUARTZ_THEME is unset", () => {
+    const preset = getThemePresetFromEnvironment({})
+
+    assert.strictEqual(preset, undefined)
+  })
+
+  test("rejects unknown theme preset names", () => {
+    assert.throws(() => getThemePreset("missing"), UnknownThemePresetError)
+    assert.throws(
+      () => getThemePreset("missing"),
+      /Unknown Quartz theme preset "missing". Expected one of: oldwinter, ink, mist, ember, atlas, sakura/,
+    )
+  })
+})

--- a/quartz/util/themePresets.ts
+++ b/quartz/util/themePresets.ts
@@ -1,0 +1,205 @@
+import type { ColorScheme, Theme } from "./theme"
+
+export const themePresetNames = ["oldwinter", "ink", "mist", "ember", "atlas", "sakura"] as const
+export type ThemePresetName = (typeof themePresetNames)[number]
+
+type ThemePresetEnvironment = Readonly<Record<string, string | undefined>>
+
+export class UnknownThemePresetError extends Error {
+  constructor(name: string) {
+    super(`Unknown Quartz theme preset "${name}". Expected one of: ${themePresetNames.join(", ")}`)
+    this.name = "UnknownThemePresetError"
+  }
+}
+
+const typography = {
+  header: {
+    name: "Schibsted Grotesk",
+    weights: [400, 600, 700],
+  },
+  body: {
+    name: "LXGW WenKai",
+    weights: [400, 600],
+    includeItalic: true,
+  },
+  code: {
+    name: "IBM Plex Mono",
+    weights: [400, 600],
+  },
+} satisfies Theme["typography"]
+
+function createTheme(lightMode: ColorScheme, darkMode: ColorScheme): Theme {
+  return {
+    fontOrigin: "googleFonts",
+    cdnCaching: true,
+    typography,
+    colors: {
+      lightMode,
+      darkMode,
+    },
+  }
+}
+
+export const quartzThemePresets: Record<ThemePresetName, Theme> = {
+  oldwinter: createTheme(
+    {
+      light: "#faf8f7",
+      lightgray: "#e6e0dd",
+      gray: "#817671",
+      darkgray: "#4b4542",
+      dark: "#24211f",
+      secondary: "#28546a",
+      tertiary: "#4f785f",
+      highlight: "rgba(143, 159, 169, 0.15)",
+      textHighlight: "#fff23688",
+    },
+    {
+      light: "#151716",
+      lightgray: "#2d3430",
+      gray: "#87938c",
+      darkgray: "#d3d8d2",
+      dark: "#f3f0ea",
+      secondary: "#8ab2c4",
+      tertiary: "#9dbb91",
+      highlight: "rgba(143, 159, 169, 0.15)",
+      textHighlight: "#b3aa0288",
+    },
+  ),
+  ink: createTheme(
+    {
+      light: "#fbfbf7",
+      lightgray: "#e4e1d8",
+      gray: "#7c776b",
+      darkgray: "#46443f",
+      dark: "#1f211f",
+      secondary: "#3f5f48",
+      tertiary: "#8a4d3a",
+      highlight: "rgba(63, 95, 72, 0.14)",
+      textHighlight: "#eadf7a88",
+    },
+    {
+      light: "#121414",
+      lightgray: "#2b302d",
+      gray: "#8d958e",
+      darkgray: "#dce1d9",
+      dark: "#f2f0e8",
+      secondary: "#9abf98",
+      tertiary: "#d89a74",
+      highlight: "rgba(154, 191, 152, 0.16)",
+      textHighlight: "#d4a44166",
+    },
+  ),
+  mist: createTheme(
+    {
+      light: "#f7faf9",
+      lightgray: "#dbe5e1",
+      gray: "#6e7f79",
+      darkgray: "#3e4c49",
+      dark: "#1b2826",
+      secondary: "#2c6b5f",
+      tertiary: "#7b4f6f",
+      highlight: "rgba(44, 107, 95, 0.13)",
+      textHighlight: "#bfe9db88",
+    },
+    {
+      light: "#101819",
+      lightgray: "#273739",
+      gray: "#8b9c9a",
+      darkgray: "#d4dfdc",
+      dark: "#f0f5f2",
+      secondary: "#82c7b8",
+      tertiary: "#d6a1c8",
+      highlight: "rgba(130, 199, 184, 0.16)",
+      textHighlight: "#6bbba066",
+    },
+  ),
+  ember: createTheme(
+    {
+      light: "#fbfaf8",
+      lightgray: "#e6e0d9",
+      gray: "#7f7770",
+      darkgray: "#4c4640",
+      dark: "#211d1a",
+      secondary: "#8d382e",
+      tertiary: "#4f6f4a",
+      highlight: "rgba(141, 56, 46, 0.12)",
+      textHighlight: "#f1c45d88",
+    },
+    {
+      light: "#181514",
+      lightgray: "#352d2a",
+      gray: "#a0928b",
+      darkgray: "#e0d5cf",
+      dark: "#fff7f0",
+      secondary: "#f08a78",
+      tertiary: "#a9c184",
+      highlight: "rgba(240, 138, 120, 0.16)",
+      textHighlight: "#ca7a3566",
+    },
+  ),
+  atlas: createTheme(
+    {
+      light: "#f8f9fb",
+      lightgray: "#dfe3e8",
+      gray: "#6d7885",
+      darkgray: "#404852",
+      dark: "#191f26",
+      secondary: "#365d86",
+      tertiary: "#7a5b1d",
+      highlight: "rgba(54, 93, 134, 0.12)",
+      textHighlight: "#d9c16f88",
+    },
+    {
+      light: "#12161c",
+      lightgray: "#2a313b",
+      gray: "#8b95a2",
+      darkgray: "#d6dde5",
+      dark: "#f4f7fb",
+      secondary: "#8bb7e0",
+      tertiary: "#d5ad4c",
+      highlight: "rgba(139, 183, 224, 0.16)",
+      textHighlight: "#aa823c66",
+    },
+  ),
+  sakura: createTheme(
+    {
+      light: "#fffafa",
+      lightgray: "#eadfe1",
+      gray: "#817478",
+      darkgray: "#4d4145",
+      dark: "#261d20",
+      secondary: "#8a3f5a",
+      tertiary: "#2f6b68",
+      highlight: "rgba(138, 63, 90, 0.12)",
+      textHighlight: "#f4c1cf88",
+    },
+    {
+      light: "#171416",
+      lightgray: "#332a2f",
+      gray: "#9c8d93",
+      darkgray: "#e3d5dc",
+      dark: "#fff5f8",
+      secondary: "#eba0be",
+      tertiary: "#8ac9be",
+      highlight: "rgba(235, 160, 190, 0.16)",
+      textHighlight: "#c86f9166",
+    },
+  ),
+}
+
+export function isThemePresetName(name: string): name is ThemePresetName {
+  return themePresetNames.some((presetName) => presetName === name)
+}
+
+export function getThemePreset(name: string): Theme {
+  if (isThemePresetName(name)) {
+    return quartzThemePresets[name]
+  }
+
+  throw new UnknownThemePresetError(name)
+}
+
+export function getThemePresetFromEnvironment(env: ThemePresetEnvironment): Theme | undefined {
+  const presetName = env["QUARTZ_THEME"]
+  return presetName ? getThemePreset(presetName) : undefined
+}


### PR DESCRIPTION
## Summary
- add six build-time Quartz theme presets: `oldwinter`, `ink`, `mist`, `ember`, `atlas`, `sakura`
- keep runtime dark mode unchanged via Quartz's existing `saved-theme="light|dark"` behavior
- allow selecting a preset with `QUARTZ_THEME=<preset>` in the v5 `quartz.ts` config entrypoint
- document the v5 theme design system and default `oldwinter` YAML theme

## Verification
- `npm test` passed: 114 tests, 32 suites
- `npx tsc --noEmit --pretty false` passed
- `npx prettier --check DESIGN.md quartz.config.yaml quartz.ts quartz/util/themePresets.ts quartz/util/themePresets.test.ts` passed
- Built all six themes with `QUARTZ_THEME=<preset> npx quartz build -d docs -o theme-v5-builds/<preset> --concurrency=1`
- Verified final generated CSS variables for each preset's light and dark modes
- Captured light/dark screenshots for all six themes; local preview sheet: `/Users/shika/Code/dg3-v5-theme-screenshots/theme-overview.png`

## Notes
- `npm run check` currently passes `tsc`, then fails on existing repository-wide Prettier issues in content/canvas/external plugin files unrelated to this change.
- Quartz build emits existing Google Fonts warnings for `LXGW WenKai` weight 400/600 Bad Request, but build exits 0 and screenshots render.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发行说明

* **新功能**
  * 新增主题预设系统，提供6套内置主题可选
  * 支持通过环境变量自定义主题选择

* **文档**
  * 完善设计系统文档，明确色彩、排版、间距等设计规范

* **样式**
  * 更新浅色/深色模式的颜色配置，优化视觉效果

* **测试**
  * 新增主题预设系统的测试用例

<!-- end of auto-generated comment: release notes by coderabbit.ai -->