### PR TITLE
feat(404): add random note recovery

### DIFF
--- a/quartz/components/pages/404.test.ts
+++ b/quartz/components/pages/404.test.ts
@@ -1,0 +1,91 @@
+import assert from "node:assert"
+import { readFileSync } from "node:fs"
+import test, { describe } from "node:test"
+import { runInNewContext } from "node:vm"
+
+type ContentIndex = Readonly<Record<string, Readonly<{ title: string; content: string }>>>
+
+type RandomLink = {
+  href: string
+  hidden: boolean
+}
+
+type ScriptScenario = {
+  readonly index: ContentIndex
+  readonly basePath: string
+  readonly pathname: string
+  readonly random: number
+}
+
+function readNotFoundScript(): string {
+  const source = readFileSync(new URL("./404.tsx", import.meta.url), "utf8")
+  const match = source.match(/__html: `([\s\S]*?)`\s*,/)
+  assert.ok(match, "404 page should contain an inline browser script")
+  return match[1]
+}
+
+function runNotFoundScript({ index, basePath, pathname, random }: ScriptScenario): RandomLink {
+  const randomLink: RandomLink = { href: basePath || "/", hidden: true }
+
+  runInNewContext(readNotFoundScript(), {
+    document: {
+      body: { dataset: { basepath: basePath } },
+      querySelector: (selector: string) => (selector === "[data-random-note]" ? randomLink : null),
+    },
+    fetchData: {
+      then: (callback: (contentIndex: ContentIndex) => void) => callback(index),
+    },
+    Math: {
+      floor: Math.floor,
+      random: () => random,
+    },
+    window: {
+      location: {
+        pathname,
+        replace: () => undefined,
+      },
+    },
+  })
+
+  return randomLink
+}
+
+describe("404 random note recovery", () => {
+  test("shows a random published note when eligible notes exist", () => {
+    // Given
+    const index = {
+      index: { title: "Home", content: "" },
+      "404": { title: "Not Found", content: "" },
+      alpha: { title: "Alpha", content: "Alpha note" },
+      beta: { title: "Beta", content: "Beta note" },
+      "tags/generated": { title: "Generated tag", content: "" },
+    } satisfies ContentIndex
+
+    // When
+    const randomLink = runNotFoundScript({
+      index,
+      basePath: "/garden",
+      pathname: "/garden/missing",
+      random: 0.99,
+    })
+
+    // Then
+    assert.equal(randomLink.href, "/garden/beta")
+    assert.equal(randomLink.hidden, false)
+  })
+
+  test("keeps the home fallback hidden when no eligible note exists", () => {
+    // Given
+    const index = {
+      index: { title: "Home", content: "" },
+      "404": { title: "Not Found", content: "" },
+    } satisfies ContentIndex
+
+    // When
+    const randomLink = runNotFoundScript({ index, basePath: "", pathname: "/missing", random: 0 })
+
+    // Then
+    assert.equal(randomLink.href, "/")
+    assert.equal(randomLink.hidden, true)
+  })
+})

--- a/quartz/components/pages/404.tsx
+++ b/quartz/components/pages/404.tsx
@@ -10,6 +10,10 @@ const NotFound: QuartzComponent = ({ cfg, ctx }: QuartzComponentProps) => {
       <h1>404</h1>
       <p>{i18n(cfg.locale).pages.error.notFound}</p>
       <a href={baseDir}>{i18n(cfg.locale).pages.error.home}</a>
+      <a href={baseDir} data-random-note hidden>
+        <span aria-hidden="true">{" · "}</span>
+        {i18n(cfg.locale).components.explorer.title}
+      </a>
       <script
         dangerouslySetInnerHTML={{
           __html: `
@@ -41,6 +45,17 @@ const NotFound: QuartzComponent = ({ cfg, ctx }: QuartzComponentProps) => {
                 var prefix = hasBasePrefix ? basePath : "";
                 var target = prefix + (prefix.endsWith("/") ? "" : "/") + lowered;
                 window.location.replace(target);
+              }
+              var randomLink = document.querySelector("[data-random-note]");
+              var noteSlugs = Object.keys(index).filter(function(slug) {
+                var item = index[slug];
+                return slug !== "404" && slug !== "index" && item.content.trim().length > 0;
+              });
+              if (randomLink != null && noteSlugs.length > 0) {
+                var randomSlug = noteSlugs[Math.floor(Math.random() * noteSlugs.length)];
+                var randomPrefix = basePath.length > 1 ? basePath : "";
+                randomLink.href = randomPrefix + "/" + randomSlug;
+                randomLink.hidden = false;
               }
             });
           }


### PR DESCRIPTION
这次构建把原本只有“返回首页”的 404 页面变成了一个轻量的花园岔路口：内容索引加载完成后，会显示“探索”入口，并随机指向一篇真正有正文的已发布笔记；无 JavaScript、无候选或索引未就绪时仍安全回退到首页。我觉得它很酷也值得合并，因为数字花园最有趣的使用方式就是漫游，断链不再只是终点，而会变成一次意外发现，同时实现只触及 404 组件和测试，容易理解也容易回滚。

## 验证

- `npm test -- quartz/components/pages/404.test.ts`：2/2 通过，覆盖子路径、空生成页过滤和无候选回退。
- `npm test`：150/150 通过。
- `npx tsc --noEmit`：通过。
- `npx prettier --check quartz/components/pages/404.tsx quartz/components/pages/404.test.ts`：通过。
- Quartz 生产构建：314 个 Markdown 输入、1901 个输出，构建成功。
- Chrome 151 真实界面 QA：375×812、768×900、1280×900 均无横向溢出或控制台错误；键盘焦点与 hover 独立可见；点击“探索”实际到达 `/aboutthegarden`。
- 双独立视觉 QA、五路代码/目标/安全/上下文/执行审查和运行时审计：全部通过，绑定提交 `05d5dbba3411b3ad151216407675b8c179f43f2b`。

构建仍会显示三条与本改动无关的既有警告：note-properties 插件使用 direct eval、`foam.md` 中有无效日期字符串、LXGW WenKai 的 Google Fonts 请求返回 400。

## 影响范围

- 只修改 404 页面组件，并新增一个针对其内联浏览器脚本的测试。
- 不新增或升级依赖，不修改配置、基础设施、主题样式、内容或共享组件。
- 随机候选仅来自构建生成的 `contentIndex`，排除 `404`、首页及正文为空的生成页。

## 回滚

回滚此提交即可恢复原有仅“返回首页”的 404 页面；没有数据迁移、配置迁移或持久状态需要清理。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 404 页面新增随机笔记链接：当存在可用笔记时，页面会随机推荐一篇内容。

* **体验优化**
  * 无可用笔记时，页面继续隐藏随机链接并保留首页回退入口。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->