### PR TITLE
feat(reader): add reading progress indicator

### DIFF
--- a/quartz/components/Body.test.ts
+++ b/quartz/components/Body.test.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert"
+import test, { describe } from "node:test"
+import { h } from "preact"
+import { render } from "preact-render-to-string"
+import { QuartzComponentProps } from "./types"
+import Body from "./Body"
+
+describe("Body", () => {
+  test("localizes the reading progress label", () => {
+    // Given
+    const Component = Body()
+    const props = {
+      cfg: { locale: "en-US" },
+      children: [],
+    } as unknown as QuartzComponentProps
+
+    // When
+    const html = render(h(Component, props))
+
+    // Then
+    assert.match(html, /aria-label="Reading progress"/)
+  })
+})

--- a/quartz/components/Body.tsx
+++ b/quartz/components/Body.tsx
@@ -1,7 +1,23 @@
+import { defaultTranslation, i18n } from "../i18n"
 import { QuartzComponent, QuartzComponentConstructor, QuartzComponentProps } from "./types"
 
-const Body: QuartzComponent = ({ children }: QuartzComponentProps) => {
-  return <div id="quartz-body">{children}</div>
+const Body: QuartzComponent = ({ cfg, children }: QuartzComponentProps) => {
+  const readingProgressTitle =
+    i18n(cfg.locale).components.readingProgress?.title ??
+    i18n(defaultTranslation).components.readingProgress!.title
+
+  return (
+    <>
+      <progress
+        class="reading-progress"
+        aria-label={readingProgressTitle}
+        max="100"
+        value="0"
+        hidden
+      />
+      <div id="quartz-body">{children}</div>
+    </>
+  )
 }
 
 export default (() => Body) satisfies QuartzComponentConstructor

--- a/quartz/components/scripts/readingProgress.test.ts
+++ b/quartz/components/scripts/readingProgress.test.ts
@@ -1,0 +1,55 @@
+import assert from "node:assert"
+import test, { describe } from "node:test"
+import { calculateReadingProgress } from "./readingProgress"
+
+describe("calculateReadingProgress", () => {
+  test("returns the percentage of the scrollable page already read", () => {
+    // Given
+    const scrollY = 300
+    const scrollHeight = 1_000
+    const viewportHeight = 400
+
+    // When
+    const progress = calculateReadingProgress(scrollY, scrollHeight, viewportHeight)
+
+    // Then
+    assert.equal(progress, 50)
+  })
+
+  test("clamps progress before the start of the page", () => {
+    // Given
+    const scrollHeight = 1_000
+    const viewportHeight = 400
+
+    // When
+    const progress = calculateReadingProgress(-20, scrollHeight, viewportHeight)
+
+    // Then
+    assert.equal(progress, 0)
+  })
+
+  test("clamps progress after the end of the page", () => {
+    // Given
+    const scrollHeight = 1_000
+    const viewportHeight = 400
+
+    // When
+    const progress = calculateReadingProgress(900, scrollHeight, viewportHeight)
+
+    // Then
+    assert.equal(progress, 100)
+  })
+
+  test("treats a page without scrollable content as complete", () => {
+    // Given
+    const scrollY = 0
+    const scrollHeight = 400
+    const viewportHeight = 400
+
+    // When
+    const progress = calculateReadingProgress(scrollY, scrollHeight, viewportHeight)
+
+    // Then
+    assert.equal(progress, 100)
+  })
+})

--- a/quartz/components/scripts/readingProgress.ts
+++ b/quartz/components/scripts/readingProgress.ts
@@ -1,0 +1,43 @@
+export function calculateReadingProgress(
+  scrollY: number,
+  scrollHeight: number,
+  viewportHeight: number,
+): number {
+  const scrollableHeight = scrollHeight - viewportHeight
+  if (scrollableHeight <= 0) return 100
+
+  return Math.min(100, Math.max(0, (scrollY / scrollableHeight) * 100))
+}
+
+export const readingProgressScript = `
+const calculateReadingProgress = ${calculateReadingProgress.toString()}
+
+document.addEventListener("nav", () => {
+  const progress = document.querySelector(".reading-progress")
+  if (progress === null) return
+
+  let animationFrame
+  const updateProgress = () => {
+    animationFrame = undefined
+    const scrollHeight = document.documentElement.scrollHeight
+    progress.hidden = scrollHeight <= window.innerHeight
+    progress.value = calculateReadingProgress(window.scrollY, scrollHeight, window.innerHeight)
+  }
+  const scheduleUpdate = () => {
+    if (animationFrame !== undefined) return
+    animationFrame = window.requestAnimationFrame(updateProgress)
+  }
+
+  updateProgress()
+  const resizeObserver = new ResizeObserver(scheduleUpdate)
+  resizeObserver.observe(document.body)
+  window.addEventListener("scroll", scheduleUpdate, { passive: true })
+  window.addEventListener("resize", scheduleUpdate)
+  window.addCleanup(() => {
+    if (animationFrame !== undefined) window.cancelAnimationFrame(animationFrame)
+    resizeObserver.disconnect()
+    window.removeEventListener("scroll", scheduleUpdate)
+    window.removeEventListener("resize", scheduleUpdate)
+  })
+})
+`

--- a/quartz/i18n/locales/definition.ts
+++ b/quartz/i18n/locales/definition.ts
@@ -35,6 +35,9 @@ export interface Translation {
     readerMode: {
       title: string
     }
+    readingProgress?: {
+      title: string
+    }
     explorer: {
       title: string
     }

--- a/quartz/i18n/locales/en-US.ts
+++ b/quartz/i18n/locales/en-US.ts
@@ -32,6 +32,9 @@ export default {
     readerMode: {
       title: "Reader mode",
     },
+    readingProgress: {
+      title: "Reading progress",
+    },
     explorer: {
       title: "Explorer",
     },

--- a/quartz/i18n/locales/zh-CN.ts
+++ b/quartz/i18n/locales/zh-CN.ts
@@ -32,6 +32,9 @@ export default {
     readerMode: {
       title: "阅读模式",
     },
+    readingProgress: {
+      title: "阅读进度",
+    },
     explorer: {
       title: "探索",
     },

--- a/quartz/plugins/emitters/componentResources.test.ts
+++ b/quartz/plugins/emitters/componentResources.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert"
+import { readFile } from "node:fs/promises"
+import test, { describe } from "node:test"
+
+describe("componentResources", () => {
+  test("includes reading progress when SPA navigation is disabled", () => {
+    // Given
+    const emitterPath = new URL("./componentResources.ts", import.meta.url)
+
+    // When
+    const source = readFile(emitterPath, "utf8")
+
+    // Then
+    return source.then((contents) => {
+      const progressIndex = contents.indexOf(
+        "componentResources.afterDOMLoaded.push(readingProgressScript)",
+      )
+      const spaBranchIndex = contents.indexOf("if (cfg.enableSPA)")
+
+      assert.notEqual(progressIndex, -1)
+      assert.ok(progressIndex < spaBranchIndex)
+    })
+  })
+})

--- a/quartz/plugins/emitters/componentResources.ts
+++ b/quartz/plugins/emitters/componentResources.ts
@@ -9,6 +9,7 @@ import popoverScript from "../../components/scripts/popover.inline"
 import baseStyles from "../../styles/base.scss"
 import customStyles from "../../styles/custom.scss"
 import popoverStyle from "../../components/styles/popover.scss"
+import { readingProgressScript } from "../../components/scripts/readingProgress"
 import { BuildCtx } from "../../util/ctx"
 import { QuartzComponent } from "../../components/types"
 import { normalizeResource } from "../../util/resources"
@@ -83,6 +84,8 @@ async function joinScripts(scripts: string[]): Promise<string> {
 
 function addGlobalPageResources(ctx: BuildCtx, componentResources: ComponentResources) {
   const cfg = ctx.cfg.configuration
+
+  componentResources.afterDOMLoaded.push(readingProgressScript)
 
   // popovers
   if (cfg.enablePopovers) {

--- a/quartz/styles/base.scss
+++ b/quartz/styles/base.scss
@@ -681,3 +681,28 @@ iframe.pdf {
   transition: width 0.2s ease;
   z-index: 9999;
 }
+
+.reading-progress {
+  appearance: none;
+  position: fixed;
+  inset: 0 auto auto 0;
+  width: 100%;
+  height: 3px;
+  border: 0;
+  background: transparent;
+  color: var(--secondary);
+  pointer-events: none;
+  z-index: 9998;
+
+  &::-webkit-progress-bar {
+    background: transparent;
+  }
+
+  &::-webkit-progress-value {
+    background: var(--secondary);
+  }
+
+  &::-moz-progress-bar {
+    background: var(--secondary);
+  }
+}


### PR DESCRIPTION
This builds a quiet, theme-aware reading progress bar across the garden: a 3px accent line tracks long-note scroll position, disappears on pages that do not scroll, works with both Quartz SPA and full-page navigation, and exposes a localized accessible label. I think it is worth merging because the garden contains many long, link-heavy notes, and this gives readers a continuous sense of place without adding controls, dependencies, or visual weight.

## Verification

- `npm test -- --test quartz/components/Body.test.ts quartz/components/scripts/readingProgress.test.ts quartz/plugins/emitters/componentResources.test.ts quartz/components/renderPage.test.ts` (14 tests passed)
- `npx tsc --noEmit`
- `npx quartz build` (1,902 files emitted)
- Changed-file Prettier check and `git diff --check`
- Real Chromium QA: desktop 0/50/100%, fixed 3px geometry, 390px mobile, short `/404` hiding, SPA rebinding, and localized accessibility label
- Non-SPA built-script Chromium QA: 0/50/100%

The full `npm test` baseline remains 148/149 because `local-plugins/theme-switcher/test/themeSwitcherScript.test.ts` imports undeclared `jsdom`; this change does not touch that plugin or dependency state. Repository-wide `npm run check` also retains existing unrelated Prettier warnings; all changed files pass Prettier.

## Impact

- Adds one semantic `<progress>` element, one small browser listener, localized English/Chinese labels, and scoped styles.
- No dependency, configuration, infrastructure, CI, deployment, permission, secret, or content changes.
- Scroll/resize work is animation-frame coalesced, and SPA cleanup removes listeners, observer, and pending frames.

## Rollback

Revert commit `db610d9291309f76d712a71f235e20b34e6faa74`. There is no migration or persisted data to unwind.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增页面顶部阅读进度条，随阅读位置实时更新。
  * 支持无滚动内容、窗口调整及页面导航等场景。
  * 新增英文和简体中文的阅读进度标签。

* **样式**
  * 优化进度条外观，并兼容主流浏览器。

* **测试**
  * 增加阅读进度计算、组件渲染及资源加载相关测试。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->