### PR TITLE
feat(reader): add local read-later list

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -162,6 +162,15 @@ Layout rules:
 - **Accessibility**: The arrow is decorative; the button name and tooltip follow the page language. Hidden state is removed from keyboard and accessibility navigation.
 - **Motion**: Visibility uses the existing 150ms micro transition. Press feedback scales to 93%, following the beui button mechanism; reduced-motion mode removes spatial and smooth-scroll motion.
 
+### ReadLater
+
+- **Structure**: One stable 40px bookmark trigger after content metadata opens a 320px anchored panel with a current-note toggle and a bounded list of saved links. The panel follows the beui popover attachment and dismissal contract without adding its gooey morph or a motion dependency.
+- **Placement**: Inline-end below content metadata; the panel remains within `100vw - 32px`, uses the existing 6px control radius, and is hidden from print.
+- **States**: Empty, populated, current note saved, current note unsaved, hover, pressed, focus-visible, browser-storage failure, and cross-tab synchronization.
+- **Storage**: Keep at most 20 newest entries in `localStorage`; accept only root-relative paths and normalized plain-text titles. No content writes, accounts, cookies, analytics, or external requests.
+- **Accessibility**: Chinese and English names include the current saved count. The trigger reports expanded state, the current-note toggle reports pressed state, status changes use a polite live region, Escape restores trigger focus, and every remove action names its note.
+- **Motion**: Open and close are immediate. Existing 150ms micro transitions cover color and press feedback; reduced-motion mode removes the press transform.
+
 ## 6. Motion & Interaction
 
 Motion is quiet utility feedback, not brand theater.

--- a/quartz/components/renderPage.test.ts
+++ b/quartz/components/renderPage.test.ts
@@ -1,6 +1,11 @@
 import test, { describe } from "node:test"
 import assert from "node:assert"
-import { pageResources, renderTranscludes, resolvePageLocale } from "./renderPage"
+import {
+  pageResources,
+  readLaterTriggerLabels,
+  renderTranscludes,
+  resolvePageLocale,
+} from "./renderPage"
 import { Root, Element } from "hast"
 import { FullSlug } from "../util/path"
 import { GlobalConfiguration } from "../cfg"
@@ -59,6 +64,17 @@ describe("resolvePageLocale", () => {
     assert.equal(resolvePageLocale("constructor", "zh-CN"), "zh-CN")
     assert.equal(resolvePageLocale({}, "zh-CN"), "zh-CN")
   })
+})
+
+test("readLaterTriggerLabels evaluates bounded counts through the locale function", () => {
+  const labels = readLaterTriggerLabels(({ count }) =>
+    count === 1 ? "One saved note" : `${count} saved notes`,
+  )
+
+  assert.equal(labels[0], "0 saved notes")
+  assert.equal(labels[1], "One saved note")
+  assert.equal(labels[20], "20 saved notes")
+  assert.equal(labels.length, 21)
 })
 
 function makeComponentData(

--- a/quartz/components/renderPage.tsx
+++ b/quartz/components/renderPage.tsx
@@ -16,6 +16,7 @@ import { styleText } from "util"
 import { resolveFrame } from "./frames"
 import type { TreeTransform } from "../plugins/types"
 import type { BuildCtx } from "../util/ctx"
+import { READ_LATER_LIMIT } from "./scripts/readLaterStorage"
 
 interface RenderComponents {
   head: QuartzComponent
@@ -44,6 +45,12 @@ export function resolvePageLocale(language: unknown, fallback: ValidLocale): Val
       return candidate === normalized || candidate.startsWith(`${normalized}-`)
     }) as ValidLocale | undefined) ?? fallback
   )
+}
+
+export function readLaterTriggerLabels(
+  trigger: (variables: { count: number }) => string,
+): readonly string[] {
+  return Array.from({ length: READ_LATER_LIMIT + 1 }, (_, count) => trigger({ count }))
 }
 
 export function pageResources(
@@ -374,7 +381,7 @@ export function renderPage(
         data-heading-permalink-copied-title={headingPermalink.copiedTitle}
         data-heading-permalink-copied-label={headingPermalink.copiedLabel}
         data-read-later-title={readLater.title}
-        data-read-later-trigger={readLater.trigger({ count: "{count}" })}
+        data-read-later-trigger={JSON.stringify(readLaterTriggerLabels(readLater.trigger))}
         data-read-later-save={readLater.save}
         data-read-later-remove-current={readLater.removeCurrent}
         data-read-later-remove-item={readLater.removeItem({ title: "{title}" })}

--- a/quartz/components/renderPage.tsx
+++ b/quartz/components/renderPage.tsx
@@ -356,6 +356,8 @@ export function renderPage(
   const pageLocale = resolvePageLocale(lang, cfg.locale)
   const fallbackHeadingPermalink = TRANSLATIONS[defaultTranslation].components.headingPermalink
   const headingPermalink = i18n(pageLocale).components.headingPermalink ?? fallbackHeadingPermalink
+  const fallbackReadLater = TRANSLATIONS[defaultTranslation].components.readLater
+  const readLater = i18n(pageLocale).components.readLater ?? fallbackReadLater
   // During local dev (--serve), the dev server serves from root without the
   // baseUrl subpath, so basePath must be empty to avoid broken links.
   const basePath =
@@ -371,6 +373,16 @@ export function renderPage(
         data-heading-permalink-label={headingPermalink.title}
         data-heading-permalink-copied-title={headingPermalink.copiedTitle}
         data-heading-permalink-copied-label={headingPermalink.copiedLabel}
+        data-read-later-title={readLater.title}
+        data-read-later-trigger={readLater.trigger}
+        data-read-later-save={readLater.save}
+        data-read-later-remove-current={readLater.removeCurrent}
+        data-read-later-remove-item={readLater.removeItem}
+        data-read-later-close={readLater.close}
+        data-read-later-empty={readLater.empty}
+        data-read-later-saved={readLater.saved}
+        data-read-later-removed={readLater.removed}
+        data-read-later-failed={readLater.failed}
       >
         {frame.css && <style dangerouslySetInnerHTML={{ __html: frame.css }} />}
         <div id="quartz-root" class="page" data-frame={frame.name}>

--- a/quartz/components/renderPage.tsx
+++ b/quartz/components/renderPage.tsx
@@ -374,10 +374,10 @@ export function renderPage(
         data-heading-permalink-copied-title={headingPermalink.copiedTitle}
         data-heading-permalink-copied-label={headingPermalink.copiedLabel}
         data-read-later-title={readLater.title}
-        data-read-later-trigger={readLater.trigger}
+        data-read-later-trigger={readLater.trigger({ count: "{count}" })}
         data-read-later-save={readLater.save}
         data-read-later-remove-current={readLater.removeCurrent}
-        data-read-later-remove-item={readLater.removeItem}
+        data-read-later-remove-item={readLater.removeItem({ title: "{title}" })}
         data-read-later-close={readLater.close}
         data-read-later-empty={readLater.empty}
         data-read-later-saved={readLater.saved}

--- a/quartz/components/scripts/readLater.test.ts
+++ b/quartz/components/scripts/readLater.test.ts
@@ -29,7 +29,9 @@ describe("read-later storage", () => {
     const stored = JSON.stringify([
       { path: "/older", title: " Older copy ", savedAt: 10 },
       { path: "javascript:alert(1)", title: "Unsafe", savedAt: 40 },
-      { path: "/\n/evil.example", title: "Control character", savedAt: 40 },
+      { path: "/\n/evil.example", title: "Line feed", savedAt: 40 },
+      { path: "/\r/evil.example", title: "Carriage return", savedAt: 40 },
+      { path: "/\t/evil.example", title: "Tab", savedAt: 40 },
       { path: "/newer", title: "Newer", savedAt: 30 },
       { path: "/older", title: "Latest copy", savedAt: 20 },
       { path: "/missing-title", title: "", savedAt: 50 },

--- a/quartz/components/scripts/readLater.test.ts
+++ b/quartz/components/scripts/readLater.test.ts
@@ -16,6 +16,12 @@ test("read-later browser script compiles", () => {
   assert.doesNotThrow(compile)
 })
 
+test("read-later browser script handles navigation and in-place renders", () => {
+  assert.match(readLaterScript, /document\.addEventListener\("nav", initializeReadLater\)/)
+  assert.match(readLaterScript, /document\.addEventListener\("render", initializeReadLater\)/)
+  assert.match(readLaterScript, /window\.addCleanup\(cleanupReadLater\)/)
+})
+
 describe("read-later storage", () => {
   test("keeps only safe, unique entries with the newest save first", () => {
     // Given

--- a/quartz/components/scripts/readLater.test.ts
+++ b/quartz/components/scripts/readLater.test.ts
@@ -24,6 +24,7 @@ test("read-later browser script handles navigation and in-place renders", () => 
   assert.match(readLaterScript, /document\.addEventListener\("render", initializeReadLater\)/)
   assert.match(readLaterScript, /window\.addCleanup\(cleanupReadLater\)/)
   assert.match(readLaterScript, /event\.key !== null && event\.key !== READ_LATER_KEY/)
+  assert.match(readLaterScript, /const current = parseReadLaterEntry\(/)
 })
 
 test("read-later labels use the central locale catalog", () => {
@@ -66,6 +67,16 @@ describe("read-later storage", () => {
 
     // Then
     assert.deepEqual(entries, [])
+  })
+
+  test("rejects a protocol-relative current page before it can be saved", () => {
+    const entries = toggleReadLaterEntry([], {
+      path: "//evil.example/note",
+      title: "Unsafe current page",
+      savedAt: 20,
+    })
+
+    assert.deepEqual(parseReadLaterEntries(JSON.stringify(entries)), [])
   })
 
   test("adds a new note to the front", () => {

--- a/quartz/components/scripts/readLater.test.ts
+++ b/quartz/components/scripts/readLater.test.ts
@@ -20,6 +20,7 @@ test("read-later browser script handles navigation and in-place renders", () => 
   assert.match(readLaterScript, /document\.addEventListener\("nav", initializeReadLater\)/)
   assert.match(readLaterScript, /document\.addEventListener\("render", initializeReadLater\)/)
   assert.match(readLaterScript, /window\.addCleanup\(cleanupReadLater\)/)
+  assert.match(readLaterScript, /event\.key !== null && event\.key !== READ_LATER_KEY/)
 })
 
 describe("read-later storage", () => {

--- a/quartz/components/scripts/readLater.test.ts
+++ b/quartz/components/scripts/readLater.test.ts
@@ -1,5 +1,8 @@
 import assert from "node:assert"
 import test, { describe } from "node:test"
+import enUs from "../../i18n/locales/en-US"
+import zhCn from "../../i18n/locales/zh-CN"
+import zhTw from "../../i18n/locales/zh-TW"
 import { readLaterScript } from "./readLater"
 import {
   READ_LATER_LIMIT,
@@ -21,6 +24,13 @@ test("read-later browser script handles navigation and in-place renders", () => 
   assert.match(readLaterScript, /document\.addEventListener\("render", initializeReadLater\)/)
   assert.match(readLaterScript, /window\.addCleanup\(cleanupReadLater\)/)
   assert.match(readLaterScript, /event\.key !== null && event\.key !== READ_LATER_KEY/)
+})
+
+test("read-later labels use the central locale catalog", () => {
+  assert.equal(enUs.components.readLater.trigger, "Read later, {count} saved")
+  assert.equal(zhCn.components.readLater.trigger, "稍后读，已保存 {count} 篇")
+  assert.equal(zhTw.components.readLater.trigger, "稍後讀，已儲存 {count} 篇")
+  assert.match(enUs.components.readLater.removeItem, /\{title\}/)
 })
 
 describe("read-later storage", () => {

--- a/quartz/components/scripts/readLater.test.ts
+++ b/quartz/components/scripts/readLater.test.ts
@@ -27,10 +27,10 @@ test("read-later browser script handles navigation and in-place renders", () => 
 })
 
 test("read-later labels use the central locale catalog", () => {
-  assert.equal(enUs.components.readLater.trigger, "Read later, {count} saved")
-  assert.equal(zhCn.components.readLater.trigger, "稍后读，已保存 {count} 篇")
-  assert.equal(zhTw.components.readLater.trigger, "稍後讀，已儲存 {count} 篇")
-  assert.match(enUs.components.readLater.removeItem, /\{title\}/)
+  assert.equal(enUs.components.readLater.trigger({ count: 2 }), "Read later, 2 saved")
+  assert.equal(zhCn.components.readLater.trigger({ count: 2 }), "稍后读，已保存 2 篇")
+  assert.equal(zhTw.components.readLater.trigger({ count: 2 }), "稍後讀，已儲存 2 篇")
+  assert.equal(enUs.components.readLater.removeItem({ title: "Note" }), "Remove Note")
 })
 
 describe("read-later storage", () => {

--- a/quartz/components/scripts/readLater.test.ts
+++ b/quartz/components/scripts/readLater.test.ts
@@ -1,0 +1,99 @@
+import assert from "node:assert"
+import test, { describe } from "node:test"
+import { readLaterScript } from "./readLater"
+import {
+  READ_LATER_LIMIT,
+  parseReadLaterEntries,
+  toggleReadLaterEntry,
+  type ReadLaterEntry,
+} from "./readLaterStorage"
+
+test("read-later browser script compiles", () => {
+  // Given
+  const compile = () => new Function(readLaterScript)
+
+  // When / Then
+  assert.doesNotThrow(compile)
+})
+
+describe("read-later storage", () => {
+  test("keeps only safe, unique entries with the newest save first", () => {
+    // Given
+    const stored = JSON.stringify([
+      { path: "/older", title: " Older copy ", savedAt: 10 },
+      { path: "javascript:alert(1)", title: "Unsafe", savedAt: 40 },
+      { path: "/newer", title: "Newer", savedAt: 30 },
+      { path: "/older", title: "Latest copy", savedAt: 20 },
+      { path: "/missing-title", title: "", savedAt: 50 },
+    ])
+
+    // When
+    const entries = parseReadLaterEntries(stored)
+
+    // Then
+    assert.deepEqual(entries, [
+      { path: "/newer", title: "Newer", savedAt: 30 },
+      { path: "/older", title: "Latest copy", savedAt: 20 },
+    ])
+  })
+
+  test("returns an empty list for malformed JSON", () => {
+    // Given
+    const malformed = "[{"
+
+    // When
+    const entries = parseReadLaterEntries(malformed)
+
+    // Then
+    assert.deepEqual(entries, [])
+  })
+
+  test("adds a new note to the front", () => {
+    // Given
+    const entries: readonly ReadLaterEntry[] = [
+      { path: "/existing", title: "Existing", savedAt: 10 },
+    ]
+    const current = { path: "/current", title: "Current", savedAt: 20 }
+
+    // When
+    const updated = toggleReadLaterEntry(entries, current)
+
+    // Then
+    assert.deepEqual(updated, [current, ...entries])
+  })
+
+  test("removes a note that is already saved", () => {
+    // Given
+    const current = { path: "/current", title: "Current", savedAt: 20 }
+    const entries: readonly ReadLaterEntry[] = [
+      current,
+      { path: "/existing", title: "Existing", savedAt: 10 },
+    ]
+
+    // When
+    const updated = toggleReadLaterEntry(entries, current)
+
+    // Then
+    assert.deepEqual(updated, [{ path: "/existing", title: "Existing", savedAt: 10 }])
+  })
+
+  test("bounds the local list to the most recent entries", () => {
+    // Given
+    const entries: readonly ReadLaterEntry[] = Array.from(
+      { length: READ_LATER_LIMIT },
+      (_, index) => ({ path: `/note-${index}`, title: `Note ${index}`, savedAt: index }),
+    )
+    const current = { path: "/current", title: "Current", savedAt: 100 }
+
+    // When
+    const updated = toggleReadLaterEntry(entries, current)
+
+    // Then
+    assert.equal(updated.length, READ_LATER_LIMIT)
+    assert.deepEqual(updated[0], current)
+    assert.equal(
+      updated.some((entry) => entry.path === "/note-19"),
+      false,
+    )
+  })
+})

--- a/quartz/components/scripts/readLater.test.ts
+++ b/quartz/components/scripts/readLater.test.ts
@@ -29,6 +29,7 @@ describe("read-later storage", () => {
     const stored = JSON.stringify([
       { path: "/older", title: " Older copy ", savedAt: 10 },
       { path: "javascript:alert(1)", title: "Unsafe", savedAt: 40 },
+      { path: "/\n/evil.example", title: "Control character", savedAt: 40 },
       { path: "/newer", title: "Newer", savedAt: 30 },
       { path: "/older", title: "Latest copy", savedAt: 20 },
       { path: "/missing-title", title: "", savedAt: 50 },

--- a/quartz/components/scripts/readLater.ts
+++ b/quartz/components/scripts/readLater.ts
@@ -44,11 +44,14 @@ function createBookmarkIcon() {
 }
 
 let cleanupCurrentReadLater = () => {}
-const cleanupReadLater = () => cleanupCurrentReadLater()
+const cleanupReadLater = () => {
+  const cleanup = cleanupCurrentReadLater
+  cleanupCurrentReadLater = () => {}
+  cleanup()
+}
 
 function initializeReadLater() {
-  cleanupCurrentReadLater()
-  cleanupCurrentReadLater = () => {}
+  cleanupReadLater()
   const titleElement = document.querySelector("h1.article-title")
   const anchor = document.querySelector(".content-meta") ?? titleElement
   const title = titleElement?.textContent?.trim()

--- a/quartz/components/scripts/readLater.ts
+++ b/quartz/components/scripts/readLater.ts
@@ -207,7 +207,7 @@ function initializeReadLater() {
     if (event.key === "Escape" && !panel.hidden) closePanel(true)
   }
   const syncStoredEntries = (event) => {
-    if (event.key !== READ_LATER_KEY) return
+    if (event.key !== null && event.key !== READ_LATER_KEY) return
     entries = readStoredEntries()
     render()
   }

--- a/quartz/components/scripts/readLater.ts
+++ b/quartz/components/scripts/readLater.ts
@@ -43,6 +43,48 @@ function createBookmarkIcon() {
   return icon
 }
 
+function getReadLaterLabels() {
+  const {
+    readLaterTitle: title,
+    readLaterTrigger: trigger,
+    readLaterSave: save,
+    readLaterRemoveCurrent: removeCurrent,
+    readLaterRemoveItem: removeItem,
+    readLaterClose: close,
+    readLaterEmpty: empty,
+    readLaterSaved: saved,
+    readLaterRemoved: removed,
+    readLaterFailed: failed,
+  } = document.body.dataset
+  if (
+    !title ||
+    !trigger ||
+    !save ||
+    !removeCurrent ||
+    !removeItem ||
+    !close ||
+    !empty ||
+    !saved ||
+    !removed ||
+    !failed
+  ) {
+    return undefined
+  }
+
+  return {
+    title,
+    trigger: (count) => trigger.replace("{count}", () => String(count)),
+    save,
+    removeCurrent,
+    removeItem: (name) => removeItem.replace("{title}", () => name),
+    close,
+    empty,
+    saved,
+    removed,
+    failed,
+  }
+}
+
 let cleanupCurrentReadLater = () => {}
 const cleanupReadLater = () => {
   const cleanup = cleanupCurrentReadLater
@@ -55,34 +97,8 @@ function initializeReadLater() {
   const titleElement = document.querySelector("h1.article-title")
   const anchor = document.querySelector(".content-meta") ?? titleElement
   const title = titleElement?.textContent?.trim()
-  if (anchor === null || !title) return
-
-  const isChinese = document.documentElement.lang.toLowerCase().startsWith("zh")
-  const labels = isChinese
-    ? {
-        title: "稍后读",
-        trigger: (count) => "稍后读，已保存 " + count + " 篇",
-        save: "保存当前笔记",
-        removeCurrent: "从稍后读移除",
-        removeItem: (name) => "移除《" + name + "》",
-        close: "关闭稍后读",
-        empty: "还没有稍后读笔记",
-        saved: "已加入稍后读",
-        removed: "已从稍后读移除",
-        failed: "浏览器未能保存更改",
-      }
-    : {
-        title: "Read later",
-        trigger: (count) => "Read later, " + count + " saved",
-        save: "Save this note",
-        removeCurrent: "Remove this note",
-        removeItem: (name) => "Remove " + name,
-        close: "Close read later",
-        empty: "No saved notes yet",
-        saved: "Saved for later",
-        removed: "Removed from read later",
-        failed: "The browser could not save this change",
-      }
+  const labels = getReadLaterLabels()
+  if (anchor === null || !title || labels === undefined) return
 
   const current = { path: location.pathname, title, savedAt: 0 }
   let entries = readStoredEntries()

--- a/quartz/components/scripts/readLater.ts
+++ b/quartz/components/scripts/readLater.ts
@@ -1,0 +1,218 @@
+import {
+  READ_LATER_LIMIT,
+  parseReadLaterEntries,
+  parseReadLaterEntry,
+  toggleReadLaterEntry,
+} from "./readLaterStorage"
+
+export const readLaterScript = `
+const READ_LATER_KEY = "dg3.readLater.v1"
+const parseReadLaterEntry = ${parseReadLaterEntry.toString()}
+const parseReadLaterEntries = ${parseReadLaterEntries.toString()}
+const toggleReadLaterEntry = ${toggleReadLaterEntry.toString()}
+const READ_LATER_LIMIT = ${READ_LATER_LIMIT}
+
+function readStoredEntries() {
+  try {
+    return parseReadLaterEntries(localStorage.getItem(READ_LATER_KEY))
+  } catch (error) {
+    if (error instanceof DOMException) return []
+    throw error
+  }
+}
+
+function writeStoredEntries(entries) {
+  try {
+    localStorage.setItem(READ_LATER_KEY, JSON.stringify(entries))
+    return true
+  } catch (error) {
+    if (error instanceof DOMException) return false
+    throw error
+  }
+}
+
+function createBookmarkIcon() {
+  const namespace = "http://www.w3.org/2000/svg"
+  const icon = document.createElementNS(namespace, "svg")
+  icon.classList.add("read-later-icon")
+  icon.setAttribute("viewBox", "0 0 24 24")
+  icon.setAttribute("aria-hidden", "true")
+  const path = document.createElementNS(namespace, "path")
+  path.setAttribute("d", "M6 3h12a1 1 0 0 1 1 1v17l-7-5-7 5V4a1 1 0 0 1 1-1Z")
+  icon.append(path)
+  return icon
+}
+
+document.addEventListener("nav", () => {
+  document.querySelector("[data-read-later-root]")?.remove()
+  const titleElement = document.querySelector("h1.article-title")
+  const anchor = document.querySelector(".content-meta") ?? titleElement
+  const title = titleElement?.textContent?.trim()
+  if (anchor === null || !title) return
+
+  const isChinese = document.documentElement.lang.toLowerCase().startsWith("zh")
+  const labels = isChinese
+    ? {
+        title: "稍后读",
+        trigger: (count) => "稍后读，已保存 " + count + " 篇",
+        save: "保存当前笔记",
+        removeCurrent: "从稍后读移除",
+        removeItem: (name) => "移除《" + name + "》",
+        close: "关闭稍后读",
+        empty: "还没有稍后读笔记",
+        saved: "已加入稍后读",
+        removed: "已从稍后读移除",
+        failed: "浏览器未能保存更改",
+      }
+    : {
+        title: "Read later",
+        trigger: (count) => "Read later, " + count + " saved",
+        save: "Save this note",
+        removeCurrent: "Remove this note",
+        removeItem: (name) => "Remove " + name,
+        close: "Close read later",
+        empty: "No saved notes yet",
+        saved: "Saved for later",
+        removed: "Removed from read later",
+        failed: "The browser could not save this change",
+      }
+
+  const current = { path: location.pathname, title, savedAt: 0 }
+  let entries = readStoredEntries()
+  const root = document.createElement("div")
+  root.className = "read-later"
+  root.setAttribute("data-read-later-root", "")
+
+  const trigger = document.createElement("button")
+  trigger.type = "button"
+  trigger.className = "read-later-trigger"
+  trigger.setAttribute("aria-controls", "read-later-panel")
+  trigger.setAttribute("aria-expanded", "false")
+  trigger.append(createBookmarkIcon())
+  const count = document.createElement("span")
+  count.className = "read-later-count"
+  count.setAttribute("aria-hidden", "true")
+  trigger.append(count)
+
+  const panel = document.createElement("section")
+  panel.id = "read-later-panel"
+  panel.className = "read-later-panel"
+  panel.setAttribute("aria-label", labels.title)
+  panel.hidden = true
+  const header = document.createElement("header")
+  header.className = "read-later-header"
+  const heading = document.createElement("h2")
+  heading.textContent = labels.title
+  const closeButton = document.createElement("button")
+  closeButton.type = "button"
+  closeButton.className = "read-later-close"
+  closeButton.textContent = "×"
+  closeButton.title = labels.close
+  closeButton.setAttribute("aria-label", labels.close)
+  header.append(heading, closeButton)
+
+  const currentButton = document.createElement("button")
+  currentButton.type = "button"
+  currentButton.className = "read-later-current"
+  currentButton.append(createBookmarkIcon(), document.createElement("span"))
+  const list = document.createElement("ul")
+  list.className = "read-later-list"
+  const status = document.createElement("p")
+  status.className = "read-later-status"
+  status.setAttribute("aria-live", "polite")
+  panel.append(header, currentButton, list, status)
+  root.append(trigger, panel)
+  anchor.insertAdjacentElement("afterend", root)
+
+  const closePanel = (restoreFocus) => {
+    panel.hidden = true
+    trigger.setAttribute("aria-expanded", "false")
+    if (restoreFocus) trigger.focus()
+  }
+  const render = () => {
+    const currentIsSaved = entries.some((entry) => entry.path === current.path)
+    root.toggleAttribute("data-current-saved", currentIsSaved)
+    currentButton.setAttribute("aria-pressed", String(currentIsSaved))
+    currentButton.lastElementChild.textContent = currentIsSaved
+      ? labels.removeCurrent
+      : labels.save
+    count.hidden = entries.length === 0
+    count.textContent = String(entries.length)
+    trigger.title = labels.trigger(entries.length)
+    trigger.setAttribute("aria-label", labels.trigger(entries.length))
+    list.replaceChildren()
+    if (entries.length === 0) {
+      const empty = document.createElement("li")
+      empty.className = "read-later-empty"
+      empty.textContent = labels.empty
+      list.append(empty)
+      return
+    }
+    for (const entry of entries) {
+      const item = document.createElement("li")
+      const link = document.createElement("a")
+      link.className = "read-later-link internal"
+      link.href = entry.path
+      link.textContent = entry.title
+      link.addEventListener("click", () => closePanel(false))
+      const removeButton = document.createElement("button")
+      removeButton.type = "button"
+      removeButton.className = "read-later-remove"
+      removeButton.textContent = "×"
+      removeButton.title = labels.removeItem(entry.title)
+      removeButton.setAttribute("aria-label", labels.removeItem(entry.title))
+      removeButton.addEventListener("click", () => {
+        const next = entries.filter((candidate) => candidate.path !== entry.path)
+        if (!writeStoredEntries(next)) {
+          status.textContent = labels.failed
+          return
+        }
+        entries = next
+        status.textContent = labels.removed
+        render()
+      })
+      item.append(link, removeButton)
+      list.append(item)
+    }
+  }
+
+  trigger.addEventListener("click", () => {
+    panel.hidden = !panel.hidden
+    trigger.setAttribute("aria-expanded", String(!panel.hidden))
+    if (!panel.hidden) currentButton.focus()
+  })
+  closeButton.addEventListener("click", () => closePanel(true))
+  currentButton.addEventListener("click", () => {
+    const wasSaved = entries.some((entry) => entry.path === current.path)
+    const next = toggleReadLaterEntry(entries, { ...current, savedAt: Date.now() })
+    if (!writeStoredEntries(next)) {
+      status.textContent = labels.failed
+      return
+    }
+    entries = next
+    status.textContent = wasSaved ? labels.removed : labels.saved
+    render()
+  })
+  const dismissOutside = (event) => {
+    if (event.target instanceof Node && !root.contains(event.target)) closePanel(false)
+  }
+  const dismissWithKeyboard = (event) => {
+    if (event.key === "Escape" && !panel.hidden) closePanel(true)
+  }
+  const syncStoredEntries = (event) => {
+    if (event.key !== READ_LATER_KEY) return
+    entries = readStoredEntries()
+    render()
+  }
+  document.addEventListener("pointerdown", dismissOutside)
+  document.addEventListener("keydown", dismissWithKeyboard)
+  window.addEventListener("storage", syncStoredEntries)
+  window.addCleanup(() => {
+    document.removeEventListener("pointerdown", dismissOutside)
+    document.removeEventListener("keydown", dismissWithKeyboard)
+    window.removeEventListener("storage", syncStoredEntries)
+    root.remove()
+  })
+  render()
+})
+`

--- a/quartz/components/scripts/readLater.ts
+++ b/quartz/components/scripts/readLater.ts
@@ -46,7 +46,7 @@ function createBookmarkIcon() {
 function getReadLaterLabels() {
   const {
     readLaterTitle: title,
-    readLaterTrigger: trigger,
+    readLaterTrigger: serializedTriggers,
     readLaterSave: save,
     readLaterRemoveCurrent: removeCurrent,
     readLaterRemoveItem: removeItem,
@@ -58,7 +58,7 @@ function getReadLaterLabels() {
   } = document.body.dataset
   if (
     !title ||
-    !trigger ||
+    !serializedTriggers ||
     !save ||
     !removeCurrent ||
     !removeItem ||
@@ -71,9 +71,23 @@ function getReadLaterLabels() {
     return undefined
   }
 
+  let triggers
+  try {
+    triggers = JSON.parse(serializedTriggers)
+  } catch {
+    return undefined
+  }
+  if (
+    !Array.isArray(triggers) ||
+    triggers.length !== READ_LATER_LIMIT + 1 ||
+    triggers.some((label) => typeof label !== "string" || label.length === 0)
+  ) {
+    return undefined
+  }
+
   return {
     title,
-    trigger: (count) => trigger.replace("{count}", () => String(count)),
+    trigger: (count) => triggers[count],
     save,
     removeCurrent,
     removeItem: (name) => removeItem.replace("{title}", () => name),

--- a/quartz/components/scripts/readLater.ts
+++ b/quartz/components/scripts/readLater.ts
@@ -43,8 +43,12 @@ function createBookmarkIcon() {
   return icon
 }
 
-document.addEventListener("nav", () => {
-  document.querySelector("[data-read-later-root]")?.remove()
+let cleanupCurrentReadLater = () => {}
+const cleanupReadLater = () => cleanupCurrentReadLater()
+
+function initializeReadLater() {
+  cleanupCurrentReadLater()
+  cleanupCurrentReadLater = () => {}
   const titleElement = document.querySelector("h1.article-title")
   const anchor = document.querySelector(".content-meta") ?? titleElement
   const title = titleElement?.textContent?.trim()
@@ -207,12 +211,16 @@ document.addEventListener("nav", () => {
   document.addEventListener("pointerdown", dismissOutside)
   document.addEventListener("keydown", dismissWithKeyboard)
   window.addEventListener("storage", syncStoredEntries)
-  window.addCleanup(() => {
+  cleanupCurrentReadLater = () => {
     document.removeEventListener("pointerdown", dismissOutside)
     document.removeEventListener("keydown", dismissWithKeyboard)
     window.removeEventListener("storage", syncStoredEntries)
     root.remove()
-  })
+  }
+  window.addCleanup(cleanupReadLater)
   render()
-})
+}
+
+document.addEventListener("nav", initializeReadLater)
+document.addEventListener("render", initializeReadLater)
 `

--- a/quartz/components/scripts/readLater.ts
+++ b/quartz/components/scripts/readLater.ts
@@ -114,7 +114,8 @@ function initializeReadLater() {
   const labels = getReadLaterLabels()
   if (anchor === null || !title || labels === undefined) return
 
-  const current = { path: location.pathname, title, savedAt: 0 }
+  const current = parseReadLaterEntry({ path: location.pathname, title, savedAt: 0 })
+  if (current === undefined) return
   let entries = readStoredEntries()
   const root = document.createElement("div")
   root.className = "read-later"

--- a/quartz/components/scripts/readLaterStorage.ts
+++ b/quartz/components/scripts/readLaterStorage.ts
@@ -18,6 +18,7 @@ export function parseReadLaterEntry(candidate: unknown): ReadLaterEntry | undefi
     !path.startsWith("/") ||
     path.startsWith("//") ||
     path.includes("\\") ||
+    /[\u0000-\u0020\u007f]/u.test(path) ||
     typeof title !== "string" ||
     typeof savedAt !== "number" ||
     !Number.isSafeInteger(savedAt) ||

--- a/quartz/components/scripts/readLaterStorage.ts
+++ b/quartz/components/scripts/readLaterStorage.ts
@@ -1,0 +1,69 @@
+export const READ_LATER_LIMIT = 20
+
+export type ReadLaterEntry = Readonly<{
+  path: string
+  title: string
+  savedAt: number
+}>
+
+export function parseReadLaterEntry(candidate: unknown): ReadLaterEntry | undefined {
+  if (typeof candidate !== "object" || candidate === null) return undefined
+
+  const path: unknown = Reflect.get(candidate, "path")
+  const title: unknown = Reflect.get(candidate, "title")
+  const savedAt: unknown = Reflect.get(candidate, "savedAt")
+  if (
+    typeof path !== "string" ||
+    path.length > 2048 ||
+    !path.startsWith("/") ||
+    path.startsWith("//") ||
+    path.includes("\\") ||
+    typeof title !== "string" ||
+    typeof savedAt !== "number" ||
+    !Number.isSafeInteger(savedAt) ||
+    savedAt < 0
+  ) {
+    return undefined
+  }
+
+  const normalizedTitle = title.trim().slice(0, 200)
+  if (normalizedTitle.length === 0) return undefined
+  return { path, title: normalizedTitle, savedAt }
+}
+
+export function parseReadLaterEntries(raw: string | null): readonly ReadLaterEntry[] {
+  if (raw === null) return []
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch (error) {
+    if (error instanceof SyntaxError) return []
+    throw error
+  }
+  if (!Array.isArray(parsed)) return []
+
+  const candidates: readonly unknown[] = parsed
+  const newestByPath = new Map<string, ReadLaterEntry>()
+  for (const candidate of candidates) {
+    const entry = parseReadLaterEntry(candidate)
+    if (entry === undefined) continue
+    const existing = newestByPath.get(entry.path)
+    if (existing === undefined || entry.savedAt > existing.savedAt) {
+      newestByPath.set(entry.path, entry)
+    }
+  }
+
+  return [...newestByPath.values()]
+    .sort((first, second) => second.savedAt - first.savedAt)
+    .slice(0, READ_LATER_LIMIT)
+}
+
+export function toggleReadLaterEntry(
+  entries: readonly ReadLaterEntry[],
+  current: ReadLaterEntry,
+): readonly ReadLaterEntry[] {
+  const withoutCurrent = entries.filter((entry) => entry.path !== current.path)
+  if (withoutCurrent.length !== entries.length) return withoutCurrent
+  return [current, ...withoutCurrent].slice(0, READ_LATER_LIMIT)
+}

--- a/quartz/components/scripts/readLaterStorage.ts
+++ b/quartz/components/scripts/readLaterStorage.ts
@@ -27,6 +27,14 @@ export function parseReadLaterEntry(candidate: unknown): ReadLaterEntry | undefi
     return undefined
   }
 
+  let resolvedPath: URL
+  try {
+    resolvedPath = new URL(path, "https://read-later.invalid/")
+  } catch {
+    return undefined
+  }
+  if (resolvedPath.origin !== "https://read-later.invalid") return undefined
+
   const normalizedTitle = title.trim().slice(0, 200)
   if (normalizedTitle.length === 0) return undefined
   return { path, title: normalizedTitle, savedAt }

--- a/quartz/components/styles/readLater.scss
+++ b/quartz/components/styles/readLater.scss
@@ -3,7 +3,8 @@
   z-index: 3;
   display: flex;
   width: fit-content;
-  margin: -0.5rem 0 1rem auto;
+  margin-block: -0.5rem 1rem;
+  margin-inline: auto 0;
   justify-content: flex-end;
 }
 

--- a/quartz/components/styles/readLater.scss
+++ b/quartz/components/styles/readLater.scss
@@ -1,0 +1,204 @@
+.read-later {
+  position: relative;
+  z-index: 3;
+  display: flex;
+  width: fit-content;
+  margin: -0.5rem 0 1rem auto;
+  justify-content: flex-end;
+}
+
+.read-later-trigger,
+.read-later-close,
+.read-later-current,
+.read-later-remove {
+  appearance: none;
+  box-sizing: border-box;
+  border: 1px solid color-mix(in srgb, var(--gray) 54%, transparent);
+  border-radius: 6px;
+  background-color: var(--light);
+  color: var(--dark);
+  font: inherit;
+  cursor: pointer;
+  touch-action: manipulation;
+  transition:
+    background-color 0.15s ease-out,
+    border-color 0.15s ease-out,
+    color 0.15s ease-out,
+    transform 0.15s ease-out;
+
+  &:hover {
+    border-color: var(--secondary);
+    background-color: var(--lightgray);
+    color: var(--secondary);
+  }
+
+  &:active {
+    transform: scale(0.96);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--secondary);
+    outline-offset: 2px;
+  }
+}
+
+.read-later-trigger {
+  position: relative;
+  display: grid;
+  width: 2.5rem;
+  height: 2.5rem;
+  padding: 0;
+  place-items: center;
+}
+
+.read-later-icon {
+  width: 1.125rem;
+  height: 1.125rem;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 2;
+}
+
+.read-later[data-current-saved] .read-later-trigger,
+.read-later-current[aria-pressed="true"] {
+  color: var(--secondary);
+
+  .read-later-icon {
+    fill: var(--highlight);
+  }
+}
+
+.read-later-count {
+  position: absolute;
+  inset-block-start: -0.375rem;
+  inset-inline-end: -0.375rem;
+  display: grid;
+  min-width: 1rem;
+  height: 1rem;
+  padding: 0 0.2rem;
+  place-items: center;
+  border: 1px solid var(--light);
+  border-radius: 999px;
+  background-color: var(--secondary);
+  color: var(--light);
+  font-family: var(--codeFont);
+  font-size: 0.625rem;
+  line-height: 1;
+}
+
+.read-later-panel {
+  position: absolute;
+  inset-block-start: calc(100% + 0.5rem);
+  inset-inline-end: 0;
+  box-sizing: border-box;
+  width: min(20rem, calc(100vw - 2rem));
+  padding: 0.75rem;
+  border: 1px solid color-mix(in srgb, var(--gray) 54%, transparent);
+  border-radius: 6px;
+  background-color: var(--light);
+  color: var(--darkgray);
+
+  &[hidden] {
+    display: none;
+  }
+}
+
+.read-later-header {
+  display: flex;
+  min-height: 2rem;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+
+  h2 {
+    margin: 0;
+    font-size: 1rem;
+    letter-spacing: 0;
+    line-height: 1.25;
+  }
+}
+
+.read-later-close,
+.read-later-remove {
+  display: grid;
+  width: 2rem;
+  height: 2rem;
+  flex: 0 0 2rem;
+  padding: 0;
+  place-items: center;
+  font-family: var(--codeFont);
+  font-size: 1.125rem;
+  line-height: 1;
+}
+
+.read-later-current {
+  display: flex;
+  width: 100%;
+  min-height: 2.5rem;
+  margin-top: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  align-items: center;
+  gap: 0.5rem;
+  text-align: start;
+}
+
+.read-later-list {
+  max-height: 14rem;
+  margin: 0.75rem 0 0;
+  padding: 0;
+  overflow-y: auto;
+  list-style: none;
+
+  > li {
+    display: flex;
+    min-width: 0;
+    padding: 0.5rem 0;
+    align-items: center;
+    gap: 0.5rem;
+    border-top: 1px solid var(--lightgray);
+  }
+}
+
+.read-later-link {
+  min-width: 0;
+  flex: 1;
+  overflow-wrap: anywhere;
+  line-height: 1.35;
+}
+
+.read-later-empty {
+  color: var(--gray);
+  line-height: 1.5;
+}
+
+.read-later-status {
+  margin: 0.5rem 0 0;
+  color: var(--gray);
+  font-size: 0.875rem;
+  line-height: 1.4;
+
+  &:empty {
+    display: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .read-later-trigger,
+  .read-later-close,
+  .read-later-current,
+  .read-later-remove {
+    transition: none;
+
+    &:active {
+      transform: none;
+    }
+  }
+}
+
+@media print {
+  .read-later {
+    display: none;
+  }
+}

--- a/quartz/components/styles/readLater.scss
+++ b/quartz/components/styles/readLater.scss
@@ -86,6 +86,10 @@
   font-family: var(--codeFont);
   font-size: 0.625rem;
   line-height: 1;
+
+  &[hidden] {
+    display: none;
+  }
 }
 
 .read-later-panel {

--- a/quartz/components/styles/readLater.scss
+++ b/quartz/components/styles/readLater.scss
@@ -22,7 +22,6 @@
   touch-action: manipulation;
   transition:
     background-color 0.15s ease-out,
-    border-color 0.15s ease-out,
     color 0.15s ease-out,
     transform 0.15s ease-out;
 

--- a/quartz/i18n/locales/definition.ts
+++ b/quartz/i18n/locales/definition.ts
@@ -48,10 +48,10 @@ export interface Translation {
     }
     readLater?: {
       title: string
-      trigger: string
+      trigger: (variables: { count: number | string }) => string
       save: string
       removeCurrent: string
-      removeItem: string
+      removeItem: (variables: { title: string }) => string
       close: string
       empty: string
       saved: string

--- a/quartz/i18n/locales/definition.ts
+++ b/quartz/i18n/locales/definition.ts
@@ -48,7 +48,7 @@ export interface Translation {
     }
     readLater?: {
       title: string
-      trigger: (variables: { count: number | string }) => string
+      trigger: (variables: { count: number }) => string
       save: string
       removeCurrent: string
       removeItem: (variables: { title: string }) => string

--- a/quartz/i18n/locales/definition.ts
+++ b/quartz/i18n/locales/definition.ts
@@ -46,6 +46,18 @@ export interface Translation {
       copiedTitle: string
       copiedLabel: string
     }
+    readLater?: {
+      title: string
+      trigger: string
+      save: string
+      removeCurrent: string
+      removeItem: string
+      close: string
+      empty: string
+      saved: string
+      removed: string
+      failed: string
+    }
     explorer: {
       title: string
     }

--- a/quartz/i18n/locales/en-US.ts
+++ b/quartz/i18n/locales/en-US.ts
@@ -43,6 +43,18 @@ export default {
       copiedTitle: "Copied",
       copiedLabel: "Section link copied",
     },
+    readLater: {
+      title: "Read later",
+      trigger: "Read later, {count} saved",
+      save: "Save this note",
+      removeCurrent: "Remove this note",
+      removeItem: "Remove {title}",
+      close: "Close read later",
+      empty: "No saved notes yet",
+      saved: "Saved for later",
+      removed: "Removed from read later",
+      failed: "The browser could not save this change",
+    },
     explorer: {
       title: "Explorer",
     },

--- a/quartz/i18n/locales/en-US.ts
+++ b/quartz/i18n/locales/en-US.ts
@@ -45,10 +45,10 @@ export default {
     },
     readLater: {
       title: "Read later",
-      trigger: "Read later, {count} saved",
+      trigger: ({ count }) => `Read later, ${count} saved`,
       save: "Save this note",
       removeCurrent: "Remove this note",
-      removeItem: "Remove {title}",
+      removeItem: ({ title }) => `Remove ${title}`,
       close: "Close read later",
       empty: "No saved notes yet",
       saved: "Saved for later",

--- a/quartz/i18n/locales/zh-CN.ts
+++ b/quartz/i18n/locales/zh-CN.ts
@@ -43,6 +43,18 @@ export default {
       copiedTitle: "已复制",
       copiedLabel: "本节链接已复制",
     },
+    readLater: {
+      title: "稍后读",
+      trigger: "稍后读，已保存 {count} 篇",
+      save: "保存当前笔记",
+      removeCurrent: "从稍后读移除",
+      removeItem: "移除《{title}》",
+      close: "关闭稍后读",
+      empty: "还没有稍后读笔记",
+      saved: "已加入稍后读",
+      removed: "已从稍后读移除",
+      failed: "浏览器未能保存更改",
+    },
     explorer: {
       title: "探索",
     },

--- a/quartz/i18n/locales/zh-CN.ts
+++ b/quartz/i18n/locales/zh-CN.ts
@@ -45,10 +45,10 @@ export default {
     },
     readLater: {
       title: "稍后读",
-      trigger: "稍后读，已保存 {count} 篇",
+      trigger: ({ count }) => `稍后读，已保存 ${count} 篇`,
       save: "保存当前笔记",
       removeCurrent: "从稍后读移除",
-      removeItem: "移除《{title}》",
+      removeItem: ({ title }) => `移除《${title}》`,
       close: "关闭稍后读",
       empty: "还没有稍后读笔记",
       saved: "已加入稍后读",

--- a/quartz/i18n/locales/zh-TW.ts
+++ b/quartz/i18n/locales/zh-TW.ts
@@ -40,6 +40,18 @@ export default {
       copiedTitle: "已複製",
       copiedLabel: "本節連結已複製",
     },
+    readLater: {
+      title: "稍後讀",
+      trigger: "稍後讀，已儲存 {count} 篇",
+      save: "儲存目前筆記",
+      removeCurrent: "從稍後讀移除",
+      removeItem: "移除《{title}》",
+      close: "關閉稍後讀",
+      empty: "還沒有稍後讀筆記",
+      saved: "已加入稍後讀",
+      removed: "已從稍後讀移除",
+      failed: "瀏覽器未能儲存變更",
+    },
     explorer: {
       title: "探索",
     },

--- a/quartz/i18n/locales/zh-TW.ts
+++ b/quartz/i18n/locales/zh-TW.ts
@@ -42,10 +42,10 @@ export default {
     },
     readLater: {
       title: "稍後讀",
-      trigger: "稍後讀，已儲存 {count} 篇",
+      trigger: ({ count }) => `稍後讀，已儲存 ${count} 篇`,
       save: "儲存目前筆記",
       removeCurrent: "從稍後讀移除",
-      removeItem: "移除《{title}》",
+      removeItem: ({ title }) => `移除《${title}》`,
       close: "關閉稍後讀",
       empty: "還沒有稍後讀筆記",
       saved: "已加入稍後讀",

--- a/quartz/plugins/emitters/componentResources.test.ts
+++ b/quartz/plugins/emitters/componentResources.test.ts
@@ -26,4 +26,26 @@ describe("componentResources", () => {
       assert.ok(backToTopIndex < spaBranchIndex)
     })
   })
+
+  test("includes read later when SPA navigation is disabled", () => {
+    // Given
+    const emitterPath = new URL("./componentResources.ts", import.meta.url)
+
+    // When
+    const source = readFile(emitterPath, "utf8")
+
+    // Then
+    return source.then((contents) => {
+      const readLaterIndex = contents.indexOf(
+        "componentResources.afterDOMLoaded.push(readLaterScript)",
+      )
+      const readLaterStyleIndex = contents.indexOf("componentResources.css.push(readLaterStyle)")
+      const spaBranchIndex = contents.indexOf("if (cfg.enableSPA)")
+
+      assert.notEqual(readLaterIndex, -1)
+      assert.notEqual(readLaterStyleIndex, -1)
+      assert.ok(readLaterIndex < spaBranchIndex)
+      assert.ok(readLaterStyleIndex < spaBranchIndex)
+    })
+  })
 })

--- a/quartz/plugins/emitters/componentResources.ts
+++ b/quartz/plugins/emitters/componentResources.ts
@@ -11,6 +11,8 @@ import baseStyles from "../../styles/base.scss"
 import customStyles from "../../styles/custom.scss"
 import popoverStyle from "../../components/styles/popover.scss"
 import { readingProgressScript } from "../../components/scripts/readingProgress"
+import { readLaterScript } from "../../components/scripts/readLater"
+import readLaterStyle from "../../components/styles/readLater.scss"
 import { BuildCtx } from "../../util/ctx"
 import { QuartzComponent } from "../../components/types"
 import { normalizeResource } from "../../util/resources"
@@ -88,6 +90,8 @@ function addGlobalPageResources(ctx: BuildCtx, componentResources: ComponentReso
 
   componentResources.afterDOMLoaded.push(backToTopScript)
   componentResources.afterDOMLoaded.push(readingProgressScript)
+  componentResources.afterDOMLoaded.push(readLaterScript)
+  componentResources.css.push(readLaterStyle)
 
   // popovers
   if (cfg.enablePopovers) {


### PR DESCRIPTION
Adds a private, local read-later list directly to Quartz so readers can save up to 20 garden notes without an account, a server, or changes to note content. It is worth merging because it makes longer garden sessions resumable while keeping the feature origin-scoped, bounded, accessible, and fully compatible with SPA navigation.

## Summary

- add a 40px bookmark control and viewport-bounded saved-note panel
- persist newest-first entries in localStorage with a 20-note cap
- localize controls through Quartz i18n for English, Simplified Chinese, and Traditional Chinese, including count-sensitive labels
- support SPA navigation and in-place render lifecycle without duplicate roots or listeners
- reject malformed, external, control-character, and protocol-relative current or stored paths
- support keyboard dismissal, focus restoration, RTL placement, reduced motion, storage failures, and cross-tab clears

## Validation

- exact SHA: f25be5b093d9a33921d7380726b8a8862b809972
- npm test: 190/190 passing
- focused tests: 24/24 passing
- npx tsc --noEmit: passing
- feature Prettier and git diff checks: passing
- three-page Quartz fixture build: passing, 68 files emitted
- Chromium QA: save/remove/empty, zh/en/zh-TW SPA, focus/Escape, storage denial and clear, hostile paths including //zh.html, repeated render, RTL, 375px mobile, reduced motion, no page errors
- eight independent exact-SHA review lanes: PASS

## Impact

- stores only note paths, titles, and timestamps in origin-scoped localStorage
- performs no automatic network requests, content writes, cookies, analytics, or account operations
- adds a small bounded set of localized labels to each rendered page

## Rollback

Revert this PR. Existing localStorage data under dg3.readLater.v1 becomes inert and can be removed independently.

## Blockers

None.
