### PR TITLE
feat(reader): add random note wander

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -197,6 +197,14 @@ Layout rules:
 - **Accessibility**: Localize the dialog title and open/close names; use native `dialog` modal behavior for focus containment and Escape; report expanded state on the trigger; mark the current section with `aria-current="location"`; keep every target as a native hash link.
 - **Motion**: Opening and closing are immediate. Existing 150ms color and press transitions apply to controls and links; reduced-motion mode removes the press transform.
 
+### RandomWander
+
+- **Structure**: One 40px internal-link control with a shuffle icon. It joins the `ReadLater` action row when available and falls back to its own inline-end row without changing page layout.
+- **Destination**: Reuse the page's existing static content index. Choose uniformly from nonempty notes while excluding the current page, home, and 404; do not add storage, analytics, content writes, dependencies, or network requests beyond the index Quartz already loads.
+- **States**: Hidden until the content index resolves; default, hover, pressed, and focus-visible once a destination is available. Reinitialize idempotently after SPA navigation and in-place renders.
+- **Accessibility**: Use a native internal link so open-in-new-tab and browser navigation remain available. The icon is decorative; the tooltip and accessible name follow the page language.
+- **Motion**: Reuse the existing 150ms color and press feedback. Reduced-motion mode removes the press transform.
+
 ## 6. Motion & Interaction
 
 Motion is quiet utility feedback, not brand theater.

--- a/quartz/components/renderPage.tsx
+++ b/quartz/components/renderPage.tsx
@@ -369,6 +369,8 @@ export function renderPage(
   const readLater = i18n(pageLocale).components.readLater ?? fallbackReadLater
   const fallbackResumeReading = TRANSLATIONS[defaultTranslation].components.resumeReading
   const resumeReading = i18n(pageLocale).components.resumeReading ?? fallbackResumeReading
+  const fallbackRandomWander = TRANSLATIONS[defaultTranslation].components.randomWander
+  const randomWander = i18n(pageLocale).components.randomWander ?? fallbackRandomWander
   // During local dev (--serve), the dev server serves from root without the
   // baseUrl subpath, so basePath must be empty to avoid broken links.
   const basePath =
@@ -401,6 +403,7 @@ export function renderPage(
         data-resume-reading-continue={resumeReading.continueFrom}
         data-resume-reading-dismiss={resumeReading.dismiss}
         data-resume-reading-region={resumeReading.region}
+        data-random-wander-label={randomWander.title}
       >
         {frame.css && <style dangerouslySetInnerHTML={{ __html: frame.css }} />}
         <div id="quartz-root" class="page" data-frame={frame.name}>

--- a/quartz/components/scripts/randomWander.test.ts
+++ b/quartz/components/scripts/randomWander.test.ts
@@ -42,6 +42,11 @@ describe("random wander selection", () => {
       "\\evil.test": { content: "Cross-origin backslash" },
       "/evil.test": { content: "Protocol-relative path" },
       "folder/../outside": { content: "Escaped base path" },
+      "%2e%2e/%2e%2e/evil": { content: "Encoded traversal" },
+      "%2E./evil": { content: "Mixed encoded traversal" },
+      ".%2e/evil": { content: "Mixed literal traversal" },
+      "folder/%2foutside": { content: "Encoded slash" },
+      "folder/%5Coutside": { content: "Encoded backslash" },
       safe: { content: "Safe destination" },
     }
 
@@ -57,6 +62,12 @@ test("random wander builds root and subpath links", () => {
   assert.equal(randomWanderHref("", "\\evil.test"), undefined)
   assert.equal(randomWanderHref("", "/evil.test"), undefined)
   assert.equal(randomWanderHref("/garden", "folder/../outside"), undefined)
+  assert.equal(randomWanderHref("/garden", "%2e%2e/%2e%2e/evil"), undefined)
+  assert.equal(randomWanderHref("/garden", "%2E./evil"), undefined)
+  assert.equal(randomWanderHref("/garden", ".%2e/evil"), undefined)
+  assert.equal(randomWanderHref("/garden", "folder/%2foutside"), undefined)
+  assert.equal(randomWanderHref("/garden", "folder/%5Coutside"), undefined)
+  assert.equal(randomWanderHref("/garden", "80%时间输入"), "/garden/80%时间输入")
 })
 
 test("random wander browser script compiles and follows the Quartz lifecycle", () => {

--- a/quartz/components/scripts/randomWander.test.ts
+++ b/quartz/components/scripts/randomWander.test.ts
@@ -35,12 +35,28 @@ describe("random wander selection", () => {
     // When / Then
     assert.equal(pickRandomWanderSlug(currentOnly, "current", 0.5), undefined)
   })
+
+  test("rejects slugs that can escape the site origin or base path", () => {
+    // Given
+    const unsafeIndex = {
+      "\\evil.test": { content: "Cross-origin backslash" },
+      "/evil.test": { content: "Protocol-relative path" },
+      "folder/../outside": { content: "Escaped base path" },
+      safe: { content: "Safe destination" },
+    }
+
+    // When / Then
+    assert.equal(pickRandomWanderSlug(unsafeIndex, "current", 0), "safe")
+  })
 })
 
 test("random wander builds root and subpath links", () => {
   // Given / When / Then
   assert.equal(randomWanderHref("", "Cards/Delight"), "/Cards/Delight")
   assert.equal(randomWanderHref("/garden", "Cards/Delight"), "/garden/Cards/Delight")
+  assert.equal(randomWanderHref("", "\\evil.test"), undefined)
+  assert.equal(randomWanderHref("", "/evil.test"), undefined)
+  assert.equal(randomWanderHref("/garden", "folder/../outside"), undefined)
 })
 
 test("random wander browser script compiles and follows the Quartz lifecycle", () => {

--- a/quartz/components/scripts/randomWander.test.ts
+++ b/quartz/components/scripts/randomWander.test.ts
@@ -1,0 +1,62 @@
+import assert from "node:assert"
+import test, { describe } from "node:test"
+import enUs from "../../i18n/locales/en-US"
+import zhCn from "../../i18n/locales/zh-CN"
+import zhTw from "../../i18n/locales/zh-TW"
+import { pickRandomWanderSlug, randomWanderHref, randomWanderScript } from "./randomWander"
+
+describe("random wander selection", () => {
+  const index = {
+    index: { content: "Homepage" },
+    "404": { content: "Missing" },
+    current: { content: "Current note" },
+    empty: { content: "   " },
+    alpha: { content: "First destination" },
+    beta: { content: "Second destination" },
+  }
+
+  test("selects only another nonempty note", () => {
+    // Given / When
+    const first = pickRandomWanderSlug(index, "current", 0)
+    const last = pickRandomWanderSlug(index, "current", 0.999)
+
+    // Then
+    assert.equal(first, "alpha")
+    assert.equal(last, "beta")
+  })
+
+  test("returns undefined when no destination is eligible", () => {
+    // Given
+    const currentOnly = {
+      current: { content: "Current note" },
+      empty: { content: "" },
+    }
+
+    // When / Then
+    assert.equal(pickRandomWanderSlug(currentOnly, "current", 0.5), undefined)
+  })
+})
+
+test("random wander builds root and subpath links", () => {
+  // Given / When / Then
+  assert.equal(randomWanderHref("", "Cards/Delight"), "/Cards/Delight")
+  assert.equal(randomWanderHref("/garden", "Cards/Delight"), "/garden/Cards/Delight")
+})
+
+test("random wander browser script compiles and follows the Quartz lifecycle", () => {
+  // Given
+  const compile = () => new Function(randomWanderScript)
+
+  // When / Then
+  assert.doesNotThrow(compile)
+  assert.match(randomWanderScript, /document\.addEventListener\("nav", initializeRandomWander\)/)
+  assert.match(randomWanderScript, /document\.addEventListener\("render", initializeRandomWander\)/)
+  assert.match(randomWanderScript, /window\.addCleanup\(cleanupRandomWander\)/)
+})
+
+test("random wander labels use the central locale catalog", () => {
+  // Given / When / Then
+  assert.equal(enUs.components.randomWander.title, "Wander to another note")
+  assert.equal(zhCn.components.randomWander.title, "随机漫游到另一篇笔记")
+  assert.equal(zhTw.components.randomWander.title, "隨機漫遊到另一篇筆記")
+})

--- a/quartz/components/scripts/randomWander.ts
+++ b/quartz/components/scripts/randomWander.ts
@@ -1,0 +1,116 @@
+type WanderIndex = Readonly<Record<string, Readonly<{ content: string }>>>
+
+export function pickRandomWanderSlug(
+  index: WanderIndex,
+  currentSlug: string,
+  random: number,
+): string | undefined {
+  const eligibleSlugs = Object.entries(index)
+    .filter(
+      ([slug, item]) =>
+        slug !== "404" &&
+        slug !== "index" &&
+        slug !== currentSlug &&
+        item.content.trim().length > 0,
+    )
+    .map(([slug]) => slug)
+
+  return eligibleSlugs[Math.floor(random * eligibleSlugs.length)]
+}
+
+export function randomWanderHref(basePath: string, slug: string): string {
+  return `${basePath}/${slug}`
+}
+
+export const randomWanderScript = `
+const pickRandomWanderSlug = ${pickRandomWanderSlug.toString()}
+const randomWanderHref = ${randomWanderHref.toString()}
+
+function createRandomWanderIcon() {
+  const namespace = "http://www.w3.org/2000/svg"
+  const icon = document.createElementNS(namespace, "svg")
+  icon.classList.add("random-wander-icon")
+  icon.setAttribute("viewBox", "0 0 24 24")
+  icon.setAttribute("aria-hidden", "true")
+  for (const d of [
+    "m18 14 4 4-4 4",
+    "m18 2 4 4-4 4",
+    "M2 18h1.4c1.2 0 2.3-.6 3-1.6L9.6 11c.7-1 1.8-1.6 3-1.6H22",
+    "M2 6h1.9c1 0 2 .4 2.7 1.2l9.6 10.3c.7.8 1.7 1.2 2.7 1.2H22",
+  ]) {
+    const path = document.createElementNS(namespace, "path")
+    path.setAttribute("d", d)
+    icon.append(path)
+  }
+  return icon
+}
+
+let cleanupCurrentRandomWander = () => {}
+const cleanupRandomWander = () => {
+  const cleanup = cleanupCurrentRandomWander
+  cleanupCurrentRandomWander = () => {}
+  cleanup()
+}
+
+function initializeRandomWander() {
+  cleanupRandomWander()
+  const title = document.querySelector("h1.article-title")
+  const anchor = document.querySelector(".content-meta") ?? title
+  const currentSlug = document.body.dataset.slug
+  const label = document.body.dataset.randomWanderLabel
+  if (
+    title === null ||
+    anchor === null ||
+    !currentSlug ||
+    !label ||
+    typeof fetchData === "undefined"
+  ) {
+    return
+  }
+
+  let active = true
+  cleanupCurrentRandomWander = () => {
+    active = false
+  }
+  window.addCleanup(cleanupRandomWander)
+
+  fetchData.then(
+    (index) => {
+      if (!active) return
+      const slug = pickRandomWanderSlug(index, currentSlug, Math.random())
+      if (slug === undefined) return
+
+      const link = document.createElement("a")
+      link.className = "random-wander-link internal"
+      link.href = randomWanderHref(document.body.dataset.basepath ?? "", slug)
+      link.title = label
+      link.setAttribute("aria-label", label)
+      link.dataset.noPopover = ""
+      link.append(createRandomWanderIcon())
+
+      const readLater = document.querySelector("[data-read-later-root]")
+      let fallbackRoot
+      if (readLater === null) {
+        fallbackRoot = document.createElement("div")
+        fallbackRoot.className = "random-wander"
+        fallbackRoot.append(link)
+        anchor.insertAdjacentElement("afterend", fallbackRoot)
+      } else {
+        readLater.prepend(link)
+      }
+
+      cleanupCurrentRandomWander = () => {
+        active = false
+        link.remove()
+        fallbackRoot?.remove()
+      }
+    },
+    () => {
+      active = false
+    },
+  )
+}
+
+document.addEventListener("nav", initializeRandomWander)
+document.addEventListener("render", initializeRandomWander)
+`

--- a/quartz/components/scripts/randomWander.ts
+++ b/quartz/components/scripts/randomWander.ts
@@ -1,5 +1,10 @@
 type WanderIndex = Readonly<Record<string, Readonly<{ content: string }>>>
 
+export function isSafeRandomWanderSlug(slug: string): boolean {
+  if (slug.length === 0 || slug.startsWith("/") || slug.includes("\\")) return false
+  return slug.split("/").every((segment) => segment !== "." && segment !== "..")
+}
+
 export function pickRandomWanderSlug(
   index: WanderIndex,
   currentSlug: string,
@@ -11,6 +16,7 @@ export function pickRandomWanderSlug(
         slug !== "404" &&
         slug !== "index" &&
         slug !== currentSlug &&
+        isSafeRandomWanderSlug(slug) &&
         item.content.trim().length > 0,
     )
     .map(([slug]) => slug)
@@ -18,11 +24,13 @@ export function pickRandomWanderSlug(
   return eligibleSlugs[Math.floor(random * eligibleSlugs.length)]
 }
 
-export function randomWanderHref(basePath: string, slug: string): string {
+export function randomWanderHref(basePath: string, slug: string): string | undefined {
+  if (!isSafeRandomWanderSlug(slug)) return undefined
   return `${basePath}/${slug}`
 }
 
 export const randomWanderScript = `
+const isSafeRandomWanderSlug = ${isSafeRandomWanderSlug.toString()}
 const pickRandomWanderSlug = ${pickRandomWanderSlug.toString()}
 const randomWanderHref = ${randomWanderHref.toString()}
 
@@ -79,10 +87,12 @@ function initializeRandomWander() {
       if (!active) return
       const slug = pickRandomWanderSlug(index, currentSlug, Math.random())
       if (slug === undefined) return
+      const href = randomWanderHref(document.body.dataset.basepath ?? "", slug)
+      if (href === undefined) return
 
       const link = document.createElement("a")
       link.className = "random-wander-link internal"
-      link.href = randomWanderHref(document.body.dataset.basepath ?? "", slug)
+      link.href = href
       link.title = label
       link.setAttribute("aria-label", label)
       link.dataset.noPopover = ""

--- a/quartz/components/scripts/randomWander.ts
+++ b/quartz/components/scripts/randomWander.ts
@@ -2,7 +2,19 @@ type WanderIndex = Readonly<Record<string, Readonly<{ content: string }>>>
 
 export function isSafeRandomWanderSlug(slug: string): boolean {
   if (slug.length === 0 || slug.startsWith("/") || slug.includes("\\")) return false
-  return slug.split("/").every((segment) => segment !== "." && segment !== "..")
+  return slug.split("/").every((segment) => {
+    const decodedSeparators = segment
+      .replace(/%2e/gi, ".")
+      .replace(/%2f/gi, "/")
+      .replace(/%5c/gi, "\\")
+
+    return (
+      decodedSeparators !== "." &&
+      decodedSeparators !== ".." &&
+      !decodedSeparators.includes("/") &&
+      !decodedSeparators.includes("\\")
+    )
+  })
 }
 
 export function pickRandomWanderSlug(

--- a/quartz/components/styles/randomWander.scss
+++ b/quartz/components/styles/randomWander.scss
@@ -1,0 +1,75 @@
+.random-wander {
+  position: relative;
+  z-index: 3;
+  display: flex;
+  width: fit-content;
+  margin-block: -0.5rem 1rem;
+  margin-inline: auto 0;
+  justify-content: flex-end;
+}
+
+.random-wander-link {
+  display: grid;
+  box-sizing: border-box;
+  width: 2.5rem;
+  height: 2.5rem;
+  flex: 0 0 2.5rem;
+  padding: 0;
+  place-items: center;
+  border: 1px solid color-mix(in srgb, var(--gray) 54%, transparent);
+  border-radius: 6px;
+  background-color: var(--light);
+  color: var(--dark);
+  text-decoration: none;
+  touch-action: manipulation;
+  transition:
+    background-color 0.15s ease-out,
+    color 0.15s ease-out,
+    transform 0.15s ease-out;
+
+  &:hover {
+    border-color: var(--secondary);
+    background-color: var(--lightgray);
+    color: var(--secondary);
+  }
+
+  &:active {
+    transform: scale(0.96);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--secondary);
+    outline-offset: 2px;
+  }
+}
+
+.read-later > .random-wander-link {
+  margin-inline-end: 0.5rem;
+}
+
+.random-wander-icon {
+  width: 1.125rem;
+  height: 1.125rem;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 2;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .random-wander-link {
+    transition: none;
+
+    &:active {
+      transform: none;
+    }
+  }
+}
+
+@media print {
+  .random-wander,
+  .random-wander-link {
+    display: none;
+  }
+}

--- a/quartz/i18n/locales/definition.ts
+++ b/quartz/i18n/locales/definition.ts
@@ -74,6 +74,9 @@ export interface Translation {
       open: string
       close: string
     }
+    randomWander?: {
+      title: string
+    }
     explorer: {
       title: string
     }

--- a/quartz/i18n/locales/en-US.ts
+++ b/quartz/i18n/locales/en-US.ts
@@ -71,6 +71,9 @@ export default {
       open: "Open page outline",
       close: "Close page outline",
     },
+    randomWander: {
+      title: "Wander to another note",
+    },
     explorer: {
       title: "Explorer",
     },

--- a/quartz/i18n/locales/zh-CN.ts
+++ b/quartz/i18n/locales/zh-CN.ts
@@ -71,6 +71,9 @@ export default {
       open: "打开本页大纲",
       close: "关闭本页大纲",
     },
+    randomWander: {
+      title: "随机漫游到另一篇笔记",
+    },
     explorer: {
       title: "探索",
     },

--- a/quartz/i18n/locales/zh-TW.ts
+++ b/quartz/i18n/locales/zh-TW.ts
@@ -68,6 +68,9 @@ export default {
       open: "開啟本頁大綱",
       close: "關閉本頁大綱",
     },
+    randomWander: {
+      title: "隨機漫遊到另一篇筆記",
+    },
     explorer: {
       title: "探索",
     },

--- a/quartz/plugins/emitters/componentResources.test.ts
+++ b/quartz/plugins/emitters/componentResources.test.ts
@@ -101,4 +101,28 @@ describe("componentResources", () => {
       assert.ok(styleIndex < spaBranchIndex)
     })
   })
+
+  test("includes random wander when SPA navigation is disabled", () => {
+    // Given
+    const emitterPath = new URL("./componentResources.ts", import.meta.url)
+
+    // When
+    const source = readFile(emitterPath, "utf8")
+
+    // Then
+    return source.then((contents) => {
+      const randomWanderIndex = contents.indexOf(
+        "componentResources.afterDOMLoaded.push(randomWanderScript)",
+      )
+      const randomWanderStyleIndex = contents.indexOf(
+        "componentResources.css.push(randomWanderStyle)",
+      )
+      const spaBranchIndex = contents.indexOf("if (cfg.enableSPA)")
+
+      assert.notEqual(randomWanderIndex, -1)
+      assert.notEqual(randomWanderStyleIndex, -1)
+      assert.ok(randomWanderIndex < spaBranchIndex)
+      assert.ok(randomWanderStyleIndex < spaBranchIndex)
+    })
+  })
 })

--- a/quartz/plugins/emitters/componentResources.ts
+++ b/quartz/plugins/emitters/componentResources.ts
@@ -20,6 +20,8 @@ import resumeReadingStyle from "../../components/styles/resumeReading.scss"
 import quoteLinkStyle from "../../components/styles/quoteLink.scss"
 import { mobileOutlineScript } from "../../components/scripts/mobileOutline"
 import mobileOutlineStyle from "../../components/styles/mobileOutline.scss"
+import { randomWanderScript } from "../../components/scripts/randomWander"
+import randomWanderStyle from "../../components/styles/randomWander.scss"
 import { BuildCtx } from "../../util/ctx"
 import { QuartzComponent } from "../../components/types"
 import { normalizeResource } from "../../util/resources"
@@ -106,6 +108,8 @@ function addGlobalPageResources(ctx: BuildCtx, componentResources: ComponentReso
   componentResources.css.push(quoteLinkStyle)
   componentResources.afterDOMLoaded.push(mobileOutlineScript)
   componentResources.css.push(mobileOutlineStyle)
+  componentResources.afterDOMLoaded.push(randomWanderScript)
+  componentResources.css.push(randomWanderStyle)
 
   // popovers
   if (cfg.enablePopovers) {


### PR DESCRIPTION
Random Wander adds a small shuffle action beside Read Later on every normal note, sending the reader to another nonempty note without repeating the current page or landing on home/404 content. It feels worth merging because it turns a large personal knowledge garden into something pleasantly explorable with one click, while staying native to Quartz navigation, localized, accessible, and easy to remove.

## Validation

- `npx tsx --test quartz/components/scripts/randomWander.test.ts quartz/plugins/emitters/componentResources.test.ts` - 9/9 passed
- `npx tsc --noEmit` - passed
- `npx prettier --check quartz/components/scripts/randomWander.ts quartz/components/scripts/randomWander.test.ts` - passed
- `npx quartz build` - passed with 314 inputs and 1906 outputs
- Real Chrome QA - passed for SPA navigation, repeated-render idempotency, keyboard activation, native new-tab behavior, 404 exclusion, rejected index, hostile raw/encoded slugs, dark mode, reduced motion, and 1280/768/375px layouts
- Full `npm test` - 187/188 passed; the sole failure is the pre-existing ThemeSwitcher test's undeclared `jsdom` import

## Impact

- Adds one isolated reader script/style, central locale strings, render data attributes, resource registration, focused tests, and a short design contract
- Reuses the existing content index promise; adds no dependency, request, storage, analytics, configuration, infrastructure, or content changes
- Filters raw and encoded path escapes before an internal destination is rendered

## Rollback

Revert the three commits in this PR. The feature is isolated to Random Wander resources plus their locale/render registrations, so removal does not require data cleanup or migration.
