### PR TITLE
feat(reader): share the current note

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -204,6 +204,12 @@ Layout rules:
 - **States**: Hidden until the content index resolves; default, hover, pressed, and focus-visible once a destination is available. Reinitialize idempotently after SPA navigation and in-place renders.
 - **Accessibility**: Use a native internal link so open-in-new-tab and browser navigation remain available. The icon is decorative; the tooltip and accessible name follow the page language.
 - **Motion**: Reuse the existing 150ms color and press feedback. Reduced-motion mode removes the press transform.
+### NoteShare
+
+- **Structure**: One 40px share action beside `ReadLater`; it uses the browser's native share sheet when available and copies the current note URL otherwise. If `ReadLater` is unavailable, the action keeps the same inline-end placement in its own compact action group.
+- **States**: Default, native share pending, shared, copied, cancelled, clipboard failure, hover, pressed, focus-visible, and disabled. Successful actions swap the share icon to a check for 1.8 seconds; cancellation returns silently to default.
+- **Accessibility**: The button and polite live region use page-localized names and outcomes. The icon is decorative, the control remains keyboard-operable, and whole-note links omit heading fragments so section sharing stays owned by heading permalinks.
+- **Motion**: The beui `action-swap` blur/scale mechanism is adapted to the existing 150ms micro token, using a 3px blur and 75% scale only during the icon crossfade. Reduced-motion mode removes blur, scale, and press transforms while preserving the state change.
 
 ## 6. Motion & Interaction
 

--- a/quartz/components/renderPage.tsx
+++ b/quartz/components/renderPage.tsx
@@ -371,6 +371,8 @@ export function renderPage(
   const resumeReading = i18n(pageLocale).components.resumeReading ?? fallbackResumeReading
   const fallbackRandomWander = TRANSLATIONS[defaultTranslation].components.randomWander
   const randomWander = i18n(pageLocale).components.randomWander ?? fallbackRandomWander
+  const fallbackNoteShare = TRANSLATIONS[defaultTranslation].components.noteShare
+  const noteShare = i18n(pageLocale).components.noteShare ?? fallbackNoteShare
   // During local dev (--serve), the dev server serves from root without the
   // baseUrl subpath, so basePath must be empty to avoid broken links.
   const basePath =
@@ -404,6 +406,10 @@ export function renderPage(
         data-resume-reading-dismiss={resumeReading.dismiss}
         data-resume-reading-region={resumeReading.region}
         data-random-wander-label={randomWander.title}
+        data-note-share-title={noteShare.title}
+        data-note-share-shared={noteShare.shared}
+        data-note-share-copied={noteShare.copied}
+        data-note-share-failed={noteShare.failed}
       >
         {frame.css && <style dangerouslySetInnerHTML={{ __html: frame.css }} />}
         <div id="quartz-root" class="page" data-frame={frame.name}>

--- a/quartz/components/scripts/noteShare.test.ts
+++ b/quartz/components/scripts/noteShare.test.ts
@@ -1,0 +1,124 @@
+import assert from "node:assert"
+import test, { describe } from "node:test"
+import enUs from "../../i18n/locales/en-US"
+import zhCn from "../../i18n/locales/zh-CN"
+import zhTw from "../../i18n/locales/zh-TW"
+import { noteShareScript, shareNote, type NoteSharePlatform } from "./noteShare"
+
+const note = { title: "A useful note", url: "https://garden.example/note" }
+
+describe("shareNote", () => {
+  test("uses native sharing when the browser supports it", async () => {
+    // Given
+    const shared: ShareData[] = []
+    const copied: string[] = []
+    const platform: NoteSharePlatform = {
+      share: async (data) => {
+        shared.push(data)
+      },
+      copy: async (text) => {
+        copied.push(text)
+      },
+    }
+
+    // When
+    const outcome = await shareNote(platform, note)
+
+    // Then
+    assert.equal(outcome, "shared")
+    assert.deepEqual(shared, [note])
+    assert.deepEqual(copied, [])
+  })
+
+  test("does not copy when the native share sheet is cancelled", async () => {
+    // Given
+    const copied: string[] = []
+    const platform: NoteSharePlatform = {
+      share: async () => {
+        throw new DOMException("Cancelled", "AbortError")
+      },
+      copy: async (text) => {
+        copied.push(text)
+      },
+    }
+
+    // When
+    const outcome = await shareNote(platform, note)
+
+    // Then
+    assert.equal(outcome, "cancelled")
+    assert.deepEqual(copied, [])
+  })
+
+  test("copies the note URL when native sharing is unavailable", async () => {
+    // Given
+    const copied: string[] = []
+    const platform: NoteSharePlatform = {
+      copy: async (text) => {
+        copied.push(text)
+      },
+    }
+
+    // When
+    const outcome = await shareNote(platform, note)
+
+    // Then
+    assert.equal(outcome, "copied")
+    assert.deepEqual(copied, [note.url])
+  })
+
+  test("falls back to copying when native sharing fails", async () => {
+    // Given
+    const copied: string[] = []
+    const platform: NoteSharePlatform = {
+      share: async () => {
+        throw new DOMException("Blocked", "NotAllowedError")
+      },
+      copy: async (text) => {
+        copied.push(text)
+      },
+    }
+
+    // When
+    const outcome = await shareNote(platform, note)
+
+    // Then
+    assert.equal(outcome, "copied")
+    assert.deepEqual(copied, [note.url])
+  })
+
+  test("reports failure when the clipboard rejects the fallback", async () => {
+    // Given
+    const platform: NoteSharePlatform = {
+      copy: async () => {
+        throw new DOMException("Blocked", "NotAllowedError")
+      },
+    }
+
+    // When
+    const outcome = await shareNote(platform, note)
+
+    // Then
+    assert.equal(outcome, "failed")
+  })
+})
+
+test("note-share browser script compiles", () => {
+  // Given
+  const compile = () => new Function(noteShareScript)
+
+  // When / Then
+  assert.doesNotThrow(compile)
+})
+
+test("note-share browser script handles navigation and in-place renders", () => {
+  assert.match(noteShareScript, /document\.addEventListener\("nav", initializeNoteShare\)/)
+  assert.match(noteShareScript, /document\.addEventListener\("render", initializeNoteShare\)/)
+  assert.match(noteShareScript, /window\.addCleanup\(cleanupNoteShare\)/)
+})
+
+test("note-share labels use the central locale catalog", () => {
+  assert.equal(enUs.components.noteShare.title, "Share this note")
+  assert.equal(zhCn.components.noteShare.copied, "笔记链接已复制")
+  assert.equal(zhTw.components.noteShare.shared, "筆記已分享")
+})

--- a/quartz/components/scripts/noteShare.ts
+++ b/quartz/components/scripts/noteShare.ts
@@ -1,0 +1,171 @@
+export type NoteShareOutcome = "shared" | "copied" | "cancelled" | "failed"
+
+export type NoteSharePlatform = {
+  readonly share?: (data: ShareData) => Promise<void>
+  readonly copy: (text: string) => Promise<void>
+}
+
+export type NoteShareData = {
+  readonly title: string
+  readonly url: string
+}
+
+export async function shareNote(
+  platform: NoteSharePlatform,
+  data: NoteShareData,
+): Promise<NoteShareOutcome> {
+  if (platform.share) {
+    try {
+      await platform.share(data)
+      return "shared"
+    } catch (error) {
+      if (error instanceof DOMException && error.name === "AbortError") return "cancelled"
+      if (!(error instanceof DOMException || error instanceof TypeError)) throw error
+    }
+  }
+
+  try {
+    await platform.copy(data.url)
+    return "copied"
+  } catch (error) {
+    if (error instanceof DOMException || error instanceof TypeError) return "failed"
+    throw error
+  }
+}
+
+export const noteShareScript = `
+const shareNote = ${shareNote.toString()}
+
+function createNoteShareIcon(pathData, className) {
+  const namespace = "http://www.w3.org/2000/svg"
+  const icon = document.createElementNS(namespace, "svg")
+  icon.classList.add("note-share-icon", className)
+  icon.setAttribute("viewBox", "0 0 24 24")
+  icon.setAttribute("aria-hidden", "true")
+  const path = document.createElementNS(namespace, "path")
+  path.setAttribute("d", pathData)
+  icon.append(path)
+  return icon
+}
+
+function getNoteShareLabels() {
+  const {
+    noteShareTitle: title,
+    noteShareShared: shared,
+    noteShareCopied: copied,
+    noteShareFailed: failed,
+  } = document.body.dataset
+  if (!title || !shared || !copied || !failed) return undefined
+  return { title, shared, copied, failed }
+}
+
+let cleanupCurrentNoteShare = () => {}
+const cleanupNoteShare = () => {
+  const cleanup = cleanupCurrentNoteShare
+  cleanupCurrentNoteShare = () => {}
+  cleanup()
+}
+
+function initializeNoteShare() {
+  cleanupNoteShare()
+  const titleElement = document.querySelector("h1.article-title")
+  const anchor = document.querySelector(".content-meta") ?? titleElement
+  const title = titleElement?.textContent?.trim()
+  const labels = getNoteShareLabels()
+  if (anchor === null || !title || labels === undefined) return
+
+  const existingRoot = document.querySelector("[data-read-later-root]")
+  const root = existingRoot ?? document.createElement("div")
+  const ownsRoot = existingRoot === null
+  root.classList.add("reader-actions")
+  if (ownsRoot) {
+    root.classList.add("note-share-only")
+    anchor.insertAdjacentElement("afterend", root)
+  }
+
+  const button = document.createElement("button")
+  button.type = "button"
+  button.className = "note-share-trigger"
+  button.title = labels.title
+  button.setAttribute("aria-label", labels.title)
+  button.append(
+    createNoteShareIcon(
+      "M4 12v7a1 1 0 0 0 1 1h14a1 1 0 0 0 1-1v-7M12 16V3m0 0L7.5 7.5M12 3l4.5 4.5",
+      "note-share-icon-default",
+    ),
+    createNoteShareIcon("m5 12 4 4L19 6", "note-share-icon-success"),
+  )
+  const status = document.createElement("span")
+  status.className = "note-share-status"
+  status.setAttribute("aria-live", "polite")
+  root.prepend(button)
+  root.append(status)
+
+  let resetTimer = 0
+  const resetButton = () => {
+    delete button.dataset.state
+    button.title = labels.title
+    button.setAttribute("aria-label", labels.title)
+    status.textContent = ""
+  }
+  const showSuccess = (message) => {
+    window.clearTimeout(resetTimer)
+    button.dataset.state = "success"
+    button.title = message
+    button.setAttribute("aria-label", message)
+    status.textContent = message
+    resetTimer = window.setTimeout(resetButton, 1800)
+  }
+  const executeShare = async () => {
+    button.disabled = true
+    const copy = (text) => navigator.clipboard.writeText(text)
+    const platform =
+      typeof navigator.share === "function"
+        ? { share: (data) => navigator.share(data), copy }
+        : { copy }
+    const url = new URL(location.href)
+    url.hash = ""
+    let outcome
+    try {
+      outcome = await shareNote(platform, { title, url: url.href })
+    } catch (error) {
+      if (!(error instanceof Error)) throw error
+      outcome = "failed"
+    } finally {
+      button.disabled = false
+    }
+
+    switch (outcome) {
+      case "shared":
+        showSuccess(labels.shared)
+        break
+      case "copied":
+        showSuccess(labels.copied)
+        break
+      case "cancelled":
+        resetButton()
+        break
+      case "failed":
+        resetButton()
+        status.textContent = labels.failed
+        break
+    }
+  }
+  const handleClick = () => {
+    void executeShare()
+  }
+  button.addEventListener("click", handleClick)
+  cleanupCurrentNoteShare = () => {
+    window.clearTimeout(resetTimer)
+    button.removeEventListener("click", handleClick)
+    button.remove()
+    status.remove()
+    if (ownsRoot) root.remove()
+    else root.classList.remove("reader-actions")
+  }
+  window.addCleanup(cleanupNoteShare)
+}
+
+document.addEventListener("nav", initializeNoteShare)
+document.addEventListener("render", initializeNoteShare)
+`

--- a/quartz/components/styles/noteShare.scss
+++ b/quartz/components/styles/noteShare.scss
@@ -1,0 +1,121 @@
+.reader-actions {
+  gap: 0.5rem;
+}
+
+.note-share-only {
+  position: relative;
+  z-index: 3;
+  display: flex;
+  width: fit-content;
+  margin-block: -0.5rem 1rem;
+  margin-inline: auto 0;
+  justify-content: flex-end;
+}
+
+.note-share-trigger {
+  appearance: none;
+  position: relative;
+  display: grid;
+  width: 2.5rem;
+  height: 2.5rem;
+  padding: 0;
+  place-items: center;
+  border: 1px solid color-mix(in srgb, var(--gray) 54%, transparent);
+  border-radius: 6px;
+  background-color: var(--light);
+  color: var(--dark);
+  cursor: pointer;
+  touch-action: manipulation;
+  transition:
+    background-color 0.15s ease-out,
+    color 0.15s ease-out,
+    transform 0.15s ease-out;
+
+  &:hover {
+    border-color: var(--secondary);
+    background-color: var(--lightgray);
+    color: var(--secondary);
+  }
+
+  &:active {
+    transform: scale(0.96);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--secondary);
+    outline-offset: 2px;
+  }
+
+  &:disabled {
+    cursor: wait;
+    opacity: 0.65;
+  }
+}
+
+.note-share-icon {
+  grid-area: 1 / 1;
+  width: 1.125rem;
+  height: 1.125rem;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 2;
+  transition:
+    filter 0.15s ease-out,
+    opacity 0.15s ease-out,
+    transform 0.15s ease-out;
+}
+
+.note-share-icon-success {
+  opacity: 0;
+  filter: blur(3px);
+  transform: scale(0.75);
+}
+
+.note-share-trigger[data-state="success"] {
+  color: var(--secondary);
+
+  .note-share-icon-default {
+    opacity: 0;
+    filter: blur(3px);
+    transform: scale(0.75);
+  }
+
+  .note-share-icon-success {
+    opacity: 1;
+    filter: blur(0);
+    transform: scale(1);
+  }
+}
+
+.note-share-status {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .note-share-trigger,
+  .note-share-icon {
+    transition: none;
+  }
+
+  .note-share-trigger:active,
+  .note-share-icon {
+    transform: none;
+    filter: none;
+  }
+}
+
+@media print {
+  .note-share-trigger,
+  .note-share-only {
+    display: none;
+  }
+}

--- a/quartz/i18n/locales/definition.ts
+++ b/quartz/i18n/locales/definition.ts
@@ -77,6 +77,12 @@ export interface Translation {
     randomWander?: {
       title: string
     }
+    noteShare?: {
+      title: string
+      shared: string
+      copied: string
+      failed: string
+    }
     explorer: {
       title: string
     }

--- a/quartz/i18n/locales/en-US.ts
+++ b/quartz/i18n/locales/en-US.ts
@@ -74,6 +74,12 @@ export default {
     randomWander: {
       title: "Wander to another note",
     },
+    noteShare: {
+      title: "Share this note",
+      shared: "Note shared",
+      copied: "Note link copied",
+      failed: "The browser could not share this note",
+    },
     explorer: {
       title: "Explorer",
     },

--- a/quartz/i18n/locales/zh-CN.ts
+++ b/quartz/i18n/locales/zh-CN.ts
@@ -74,6 +74,12 @@ export default {
     randomWander: {
       title: "随机漫游到另一篇笔记",
     },
+    noteShare: {
+      title: "分享这篇笔记",
+      shared: "笔记已分享",
+      copied: "笔记链接已复制",
+      failed: "浏览器未能分享这篇笔记",
+    },
     explorer: {
       title: "探索",
     },

--- a/quartz/i18n/locales/zh-TW.ts
+++ b/quartz/i18n/locales/zh-TW.ts
@@ -71,6 +71,12 @@ export default {
     randomWander: {
       title: "隨機漫遊到另一篇筆記",
     },
+    noteShare: {
+      title: "分享這篇筆記",
+      shared: "筆記已分享",
+      copied: "筆記連結已複製",
+      failed: "瀏覽器未能分享這篇筆記",
+    },
     explorer: {
       title: "探索",
     },

--- a/quartz/plugins/emitters/componentResources.test.ts
+++ b/quartz/plugins/emitters/componentResources.test.ts
@@ -125,4 +125,22 @@ describe("componentResources", () => {
       assert.ok(randomWanderStyleIndex < spaBranchIndex)
     })
   })
+
+  test("includes note sharing when SPA navigation is disabled", () => {
+    const emitterPath = new URL("./componentResources.ts", import.meta.url)
+    const source = readFile(emitterPath, "utf8")
+
+    return source.then((contents) => {
+      const noteShareIndex = contents.indexOf(
+        "componentResources.afterDOMLoaded.push(noteShareScript)",
+      )
+      const noteShareStyleIndex = contents.indexOf("componentResources.css.push(noteShareStyle)")
+      const spaBranchIndex = contents.indexOf("if (cfg.enableSPA)")
+
+      assert.notEqual(noteShareIndex, -1)
+      assert.notEqual(noteShareStyleIndex, -1)
+      assert.ok(noteShareIndex < spaBranchIndex)
+      assert.ok(noteShareStyleIndex < spaBranchIndex)
+    })
+  })
 })

--- a/quartz/plugins/emitters/componentResources.ts
+++ b/quartz/plugins/emitters/componentResources.ts
@@ -22,6 +22,8 @@ import { mobileOutlineScript } from "../../components/scripts/mobileOutline"
 import mobileOutlineStyle from "../../components/styles/mobileOutline.scss"
 import { randomWanderScript } from "../../components/scripts/randomWander"
 import randomWanderStyle from "../../components/styles/randomWander.scss"
+import { noteShareScript } from "../../components/scripts/noteShare"
+import noteShareStyle from "../../components/styles/noteShare.scss"
 import { BuildCtx } from "../../util/ctx"
 import { QuartzComponent } from "../../components/types"
 import { normalizeResource } from "../../util/resources"
@@ -110,6 +112,8 @@ function addGlobalPageResources(ctx: BuildCtx, componentResources: ComponentReso
   componentResources.css.push(mobileOutlineStyle)
   componentResources.afterDOMLoaded.push(randomWanderScript)
   componentResources.css.push(randomWanderStyle)
+  componentResources.afterDOMLoaded.push(noteShareScript)
+  componentResources.css.push(noteShareStyle)
 
   // popovers
   if (cfg.enablePopovers) {


### PR DESCRIPTION
This builds a compact “share current note” action beside Read Later: supported browsers open their native share sheet, other browsers copy the note URL, and a restrained share-to-check animation confirms success in the page locale. I think it is worth merging because every garden note becomes one tap easier to send without adding navigation, dependencies, or persistent state, while cancellation and restricted clipboard environments still behave predictably.

## Validation

- Focused tests: 24/24 pass (`noteShare`, `componentResources`, `renderPage`)
- TypeScript: `tsc --noEmit` passes
- Formatting: all changed code/style/locale/test files pass Prettier; `DESIGN.md` retains its pre-existing whole-file formatting failure to avoid unrelated table churn
- Production build: 314 inputs / 1,906 outputs generated successfully
- Real Chrome QA: native-share adapter, real Clipboard API fallback, cancellation, double failure, reduced motion, and SPA forward/back lifecycle pass
- Responsive QA: 375×812, 768×900, and 1280×900 have one 40×40 share action, one 40×40 Read Later action, and no horizontal overflow
- Independent visual QA: PASS / PASS for function/design-system fit and visual/CJK quality
- Lighthouse, three sequential runs (median): mobile 54/93/100/100 and desktop 77/93/100/100 for Performance/Accessibility/Best Practices/SEO; the accessibility deductions are existing page-level contrast, heading-order, and landmark findings
- Full suite: 189/190 pass; the sole failure is the pre-existing undeclared `jsdom` import in `local-plugins/theme-switcher/test/themeSwitcherScript.test.ts`

## Impact

- Adds one localized reader action and its scoped CSS/browser script
- Adds no dependencies, configuration, content, storage, or infrastructure changes
- Keeps heading-fragment sharing owned by heading permalinks by sharing the note URL without its hash
- Merge-order note: open PR #16 touches several of the same reader-action integration files, so whichever PR merges second may need ordinary conflict resolution and combined UI QA

## Rollback

Revert commit `a7e7b99835eda43afded977d02281fe3dfa90854`; there is no migration, stored-data cleanup, or dependency rollback.
