### PR TITLE
feat(reader): copy links to selected passages

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -179,6 +179,15 @@ Layout rules:
 - **Accessibility**: The prompt is a named complementary region, both controls use localized accessible names, focus remains explicit when the prompt is removed, and the continue action focuses the article before scrolling.
 - **Motion**: Resume uses smooth scrolling only when motion is allowed. Hover, focus, and press feedback follow the existing 150ms reader-control contract; reduced-motion mode removes transitions and spatial press feedback.
 
+### QuoteLink
+
+- **Structure**: One 40px floating quote action appears only for a 3-280 character plain-text selection inside the current article. It copies a Markdown blockquote followed by a browser Text Fragment link to the selected passage.
+- **Placement**: Anchor 8px above the final selection line, fall below near the viewport top, and clamp within an 8px viewport inset. Hide when the selection collapses, leaves the viewport, enters code or authored controls, or the article is unavailable.
+- **States**: Hidden, ready, copying, copied, failed, hover, pressed, and focus-visible. Copied swaps the quote glyph for a check for 1.8 seconds; failure remains available for retry.
+- **Accessibility**: The icon is decorative; localized title and accessible names describe the action and result. A polite live region announces copy outcomes, Escape dismisses the action, and keyboard-created selections receive the same control.
+- **Privacy**: The action uses only the current selection and URL. It does not write content or storage, send requests, or persist selection text.
+- **Motion**: Existing 150ms micro transitions cover color and press feedback. Reduced-motion mode removes scale feedback, and print hides the action.
+
 ## 6. Motion & Interaction
 
 Motion is quiet utility feedback, not brand theater.

--- a/quartz/components/renderPage.tsx
+++ b/quartz/components/renderPage.tsx
@@ -363,6 +363,8 @@ export function renderPage(
   const pageLocale = resolvePageLocale(lang, cfg.locale)
   const fallbackHeadingPermalink = TRANSLATIONS[defaultTranslation].components.headingPermalink
   const headingPermalink = i18n(pageLocale).components.headingPermalink ?? fallbackHeadingPermalink
+  const fallbackQuoteLink = TRANSLATIONS[defaultTranslation].components.quoteLink
+  const quoteLink = i18n(pageLocale).components.quoteLink ?? fallbackQuoteLink
   const fallbackReadLater = TRANSLATIONS[defaultTranslation].components.readLater
   const readLater = i18n(pageLocale).components.readLater ?? fallbackReadLater
   const fallbackResumeReading = TRANSLATIONS[defaultTranslation].components.resumeReading
@@ -382,6 +384,10 @@ export function renderPage(
         data-heading-permalink-label={headingPermalink.title}
         data-heading-permalink-copied-title={headingPermalink.copiedTitle}
         data-heading-permalink-copied-label={headingPermalink.copiedLabel}
+        data-quote-link-title={quoteLink.title}
+        data-quote-link-copied={quoteLink.copied}
+        data-quote-link-failed={quoteLink.failed}
+        data-quote-link-open={quoteLink.open}
         data-read-later-title={readLater.title}
         data-read-later-trigger={JSON.stringify(readLaterTriggerLabels(readLater.trigger))}
         data-read-later-save={readLater.save}

--- a/quartz/components/scripts/quoteLink.inline.ts
+++ b/quartz/components/scripts/quoteLink.inline.ts
@@ -1,0 +1,224 @@
+import {
+  normalizeQuoteSelection,
+  quoteLinkLabels,
+  quoteLinkMarkdown,
+  quoteLinkPosition,
+} from "./quoteLink"
+
+const excludedSelectionSelector = [
+  "a",
+  "button",
+  "input",
+  "textarea",
+  "select",
+  "option",
+  "pre",
+  "code",
+  "svg",
+  ".katex",
+  ".MathJax",
+  '[contenteditable]:not([contenteditable="false"])',
+  "[data-no-quote-link]",
+].join(",")
+
+function createQuoteIcon() {
+  const namespace = "http://www.w3.org/2000/svg"
+  const icon = document.createElementNS(namespace, "svg")
+  icon.classList.add("quote-link-icon")
+  icon.setAttribute("viewBox", "0 0 24 24")
+  icon.setAttribute("aria-hidden", "true")
+
+  const quote = document.createElementNS(namespace, "path")
+  quote.classList.add("quote-link-icon-quote")
+  quote.setAttribute(
+    "d",
+    "M3 21c3 0 7-1 7-8V5c0-1.25-.75-2-2-2H4C2.75 3 2 3.75 2 5v6c0 1.25.75 2 2 2h4c0 4-1 5-5 6v2Zm11 0c3 0 7-1 7-8V5c0-1.25-.75-2-2-2h-4c-1.25 0-2 .75-2 2v6c0 1.25.75 2 2 2h4c0 4-1 5-5 6v2Z",
+  )
+
+  const check = document.createElementNS(namespace, "path")
+  check.classList.add("quote-link-icon-check")
+  check.setAttribute("d", "m4 12 5 5L20 6")
+  icon.append(quote, check)
+  return icon
+}
+
+function closestElement(node: Node | null): Element | null {
+  if (node instanceof Element) return node
+  return node?.parentElement ?? null
+}
+
+let cleanupCurrentQuoteLink = () => {}
+const cleanupQuoteLink = () => {
+  const cleanup = cleanupCurrentQuoteLink
+  cleanupCurrentQuoteLink = () => {}
+  cleanup()
+}
+
+function initializeQuoteLink() {
+  cleanupQuoteLink()
+
+  const article = document.querySelector(".center > article.popover-hint")
+  const labels = quoteLinkLabels(document.body.dataset)
+  if (
+    article === null ||
+    document.body.dataset.slug === "404" ||
+    labels === undefined ||
+    navigator.clipboard === undefined
+  ) {
+    return
+  }
+
+  const button = document.createElement("button")
+  button.type = "button"
+  button.className = "quote-link"
+  button.hidden = true
+  button.title = labels.title
+  button.setAttribute("aria-label", labels.title)
+  button.append(createQuoteIcon())
+
+  const status = document.createElement("span")
+  status.className = "quote-link-status"
+  status.setAttribute("aria-live", "polite")
+  document.body.append(button, status)
+
+  let currentQuote: string | undefined
+  let animationFrame: number | undefined
+  let feedbackTimer: number | undefined
+
+  const resetFeedback = () => {
+    if (feedbackTimer !== undefined) window.clearTimeout(feedbackTimer)
+    feedbackTimer = undefined
+    delete button.dataset.copied
+    delete button.dataset.failed
+    button.title = labels.title
+    button.setAttribute("aria-label", labels.title)
+  }
+
+  const hideButton = () => {
+    currentQuote = undefined
+    button.hidden = true
+    status.textContent = ""
+    resetFeedback()
+  }
+
+  const selectedQuote = () => {
+    const selection = window.getSelection()
+    if (selection === null || selection.isCollapsed || selection.rangeCount !== 1) return
+    if (!article.contains(selection.anchorNode) || !article.contains(selection.focusNode)) return
+
+    const range = selection.getRangeAt(0)
+    const start = closestElement(range.startContainer)
+    const end = closestElement(range.endContainer)
+    if (
+      start === null ||
+      end === null ||
+      start.closest(excludedSelectionSelector) !== null ||
+      end.closest(excludedSelectionSelector) !== null ||
+      range.cloneContents().querySelector(excludedSelectionSelector) !== null
+    ) {
+      return
+    }
+
+    const quote = normalizeQuoteSelection(selection.toString())
+    if (quote === undefined) return
+
+    const rects = range.getClientRects()
+    const rect = rects.item(rects.length - 1) ?? range.getBoundingClientRect()
+    if (
+      rect.width <= 0 ||
+      rect.height <= 0 ||
+      rect.bottom <= 0 ||
+      rect.top >= window.innerHeight ||
+      rect.right <= 0 ||
+      rect.left >= window.innerWidth
+    ) {
+      return
+    }
+
+    return { quote, rect }
+  }
+
+  const updateButton = () => {
+    animationFrame = undefined
+    const selected = selectedQuote()
+    if (selected === undefined) {
+      hideButton()
+      return
+    }
+
+    if (selected.quote !== currentQuote) {
+      resetFeedback()
+      status.textContent = ""
+    }
+    currentQuote = selected.quote
+    const position = quoteLinkPosition(selected.rect, window.innerWidth)
+    button.style.left = `${position.left}px`
+    button.style.top = `${position.top}px`
+    button.dataset.placement = position.placement
+    button.hidden = false
+  }
+
+  const scheduleUpdate = () => {
+    if (animationFrame !== undefined) return
+    animationFrame = window.requestAnimationFrame(updateButton)
+  }
+
+  const preserveSelection = (event: PointerEvent) => event.preventDefault()
+  const copyQuote = async () => {
+    const quote = currentQuote
+    if (quote === undefined) return
+
+    button.disabled = true
+    try {
+      const markdown = quoteLinkMarkdown(quote, new URL(window.location.href), labels.open)
+      await navigator.clipboard.writeText(markdown)
+      delete button.dataset.failed
+      button.dataset.copied = ""
+      button.title = labels.copied
+      button.setAttribute("aria-label", labels.copied)
+      status.textContent = labels.copied
+      feedbackTimer = window.setTimeout(resetFeedback, 1800)
+    } catch {
+      delete button.dataset.copied
+      button.dataset.failed = ""
+      button.title = labels.failed
+      button.setAttribute("aria-label", labels.failed)
+      status.textContent = labels.failed
+    } finally {
+      button.disabled = false
+    }
+  }
+
+  const dismissWithKeyboard = (event: KeyboardEvent) => {
+    if (event.key !== "Escape" || button.hidden) return
+    window.getSelection()?.removeAllRanges()
+    hideButton()
+  }
+
+  document.addEventListener("selectionchange", scheduleUpdate)
+  document.addEventListener("keydown", dismissWithKeyboard)
+  window.addEventListener("scroll", scheduleUpdate, { passive: true })
+  window.addEventListener("resize", scheduleUpdate)
+  button.addEventListener("pointerdown", preserveSelection)
+  button.addEventListener("click", copyQuote)
+
+  cleanupCurrentQuoteLink = () => {
+    if (animationFrame !== undefined) window.cancelAnimationFrame(animationFrame)
+    if (feedbackTimer !== undefined) window.clearTimeout(feedbackTimer)
+    document.removeEventListener("selectionchange", scheduleUpdate)
+    document.removeEventListener("keydown", dismissWithKeyboard)
+    window.removeEventListener("scroll", scheduleUpdate)
+    window.removeEventListener("resize", scheduleUpdate)
+    button.removeEventListener("pointerdown", preserveSelection)
+    button.removeEventListener("click", copyQuote)
+    button.remove()
+    status.remove()
+  }
+  if (typeof window.addCleanup === "function") window.addCleanup(cleanupQuoteLink)
+}
+
+document.addEventListener("nav", initializeQuoteLink)
+document.addEventListener("render", initializeQuoteLink)
+initializeQuoteLink()
+
+export default ""

--- a/quartz/components/scripts/quoteLink.test.ts
+++ b/quartz/components/scripts/quoteLink.test.ts
@@ -1,0 +1,97 @@
+import assert from "node:assert"
+import { readFile } from "node:fs/promises"
+import test, { describe } from "node:test"
+import enUs from "../../i18n/locales/en-US"
+import zhCn from "../../i18n/locales/zh-CN"
+import zhTw from "../../i18n/locales/zh-TW"
+import {
+  QUOTE_LINK_MAX_CHARS,
+  normalizeQuoteSelection,
+  quoteLinkLabels,
+  quoteLinkMarkdown,
+  quoteLinkPosition,
+  quoteLinkUrl,
+} from "./quoteLink"
+
+describe("quote link", () => {
+  test("self-starts while retaining idempotent Quartz lifecycle bindings", async () => {
+    const inlinePath = new URL("./quoteLink.inline.ts", import.meta.url)
+    const source = await readFile(inlinePath, "utf8")
+
+    assert.match(source, /document\.addEventListener\("nav", initializeQuoteLink\)/)
+    assert.match(source, /document\.addEventListener\("render", initializeQuoteLink\)/)
+    assert.match(source, /typeof window\.addCleanup === "function"/)
+    assert.match(source, /initializeQuoteLink\(\)\s*\n\s*export default/)
+  })
+
+  test("reads complete labels rendered by Quartz i18n", () => {
+    const labels = quoteLinkLabels({
+      quoteLinkTitle: "Copy quote link",
+      quoteLinkCopied: "Quote link copied",
+      quoteLinkFailed: "Could not copy quote",
+      quoteLinkOpen: "Open this passage",
+    } as DOMStringMap)
+
+    assert.deepEqual(labels, {
+      title: "Copy quote link",
+      copied: "Quote link copied",
+      failed: "Could not copy quote",
+      open: "Open this passage",
+    })
+    assert.equal(quoteLinkLabels({ quoteLinkTitle: "Incomplete" } as DOMStringMap), undefined)
+  })
+
+  test("normalizes prose while enforcing a bounded text fragment", () => {
+    assert.equal(normalizeQuoteSelection("  calm\n\n digital   garden  "), "calm digital garden")
+    assert.equal(normalizeQuoteSelection("短"), undefined)
+    assert.equal(normalizeQuoteSelection("x".repeat(QUOTE_LINK_MAX_CHARS + 1)), undefined)
+    assert.equal(normalizeQuoteSelection("🌱花园"), "🌱花园")
+  })
+
+  test("replaces a stale fragment and preserves the page query", () => {
+    const pageUrl = new URL("https://garden.example/note?view=reader#old-section")
+    const url = quoteLinkUrl(pageUrl, "quiet reading")
+
+    assert.equal(url.href, "https://garden.example/note?view=reader#:~:text=quiet%20reading")
+    assert.equal(pageUrl.hash, "#old-section")
+  })
+
+  test("encodes Chinese and percent signs without changing the origin", () => {
+    const url = quoteLinkUrl(new URL("https://garden.example/笔记"), "80% 时间输入")
+
+    assert.equal(url.origin, "https://garden.example")
+    assert.equal(url.hash, "#:~:text=80%25%20%E6%97%B6%E9%97%B4%E8%BE%93%E5%85%A5")
+  })
+
+  test("builds a portable Markdown quote and escapes its controlled label", () => {
+    const markdown = quoteLinkMarkdown(
+      "A useful passage",
+      new URL("https://garden.example/note"),
+      "Open [passage]",
+    )
+
+    assert.equal(
+      markdown,
+      "> A useful passage\n\n[Open \\[passage\\]](https://garden.example/note#:~:text=A%20useful%20passage)",
+    )
+  })
+
+  test("keeps the action inside the viewport and moves below top-edge selections", () => {
+    assert.deepEqual(quoteLinkPosition({ left: -20, top: 12, bottom: 34, width: 20 }, 375), {
+      left: 28,
+      top: 42,
+      placement: "below",
+    })
+    assert.deepEqual(quoteLinkPosition({ left: 360, top: 100, bottom: 122, width: 30 }, 375), {
+      left: 347,
+      top: 92,
+      placement: "above",
+    })
+  })
+
+  test("uses the central English and Chinese locale catalog", () => {
+    assert.equal(enUs.components.quoteLink.title, "Copy quote link")
+    assert.equal(zhCn.components.quoteLink.copied, "引用链接已复制")
+    assert.equal(zhTw.components.quoteLink.open, "開啟這段原文")
+  })
+})

--- a/quartz/components/scripts/quoteLink.ts
+++ b/quartz/components/scripts/quoteLink.ts
@@ -1,0 +1,66 @@
+export const QUOTE_LINK_MIN_CHARS = 3
+export const QUOTE_LINK_MAX_CHARS = 280
+
+export type QuoteLinkLabels = Readonly<{
+  title: string
+  copied: string
+  failed: string
+  open: string
+}>
+
+export type QuoteLinkPosition = Readonly<{
+  left: number
+  top: number
+  placement: "above" | "below"
+}>
+
+export function quoteLinkLabels(dataset: DOMStringMap): QuoteLinkLabels | undefined {
+  const {
+    quoteLinkTitle: title,
+    quoteLinkCopied: copied,
+    quoteLinkFailed: failed,
+    quoteLinkOpen: open,
+  } = dataset
+  if (!title || !copied || !failed || !open) return
+
+  return { title, copied, failed, open }
+}
+
+export function normalizeQuoteSelection(value: string): string | undefined {
+  const normalized = value.replace(/\s+/gu, " ").trim()
+  const length = [...normalized].length
+  if (length < QUOTE_LINK_MIN_CHARS || length > QUOTE_LINK_MAX_CHARS) return
+
+  return normalized
+}
+
+export function quoteLinkUrl(pageUrl: URL, quote: string): URL {
+  const url = new URL(pageUrl.href)
+  url.hash = `:~:text=${encodeURIComponent(quote)}`
+  return url
+}
+
+export function quoteLinkMarkdown(quote: string, pageUrl: URL, openLabel: string): string {
+  const safeLabel = openLabel.replace(/([\\\[\]])/gu, "\\$1")
+  return `> ${quote}\n\n[${safeLabel}](${quoteLinkUrl(pageUrl, quote).href})`
+}
+
+export function quoteLinkPosition(
+  rect: Pick<DOMRect, "left" | "top" | "bottom" | "width">,
+  viewportWidth: number,
+  buttonSize = 40,
+  gap = 8,
+): QuoteLinkPosition {
+  const viewportInset = 8
+  const halfButton = buttonSize / 2
+  const minimumLeft = viewportInset + halfButton
+  const maximumLeft = Math.max(minimumLeft, viewportWidth - viewportInset - halfButton)
+  const left = Math.min(maximumLeft, Math.max(minimumLeft, rect.left + rect.width / 2))
+  const hasRoomAbove = rect.top >= buttonSize + gap + viewportInset
+
+  return {
+    left,
+    top: hasRoomAbove ? rect.top - gap : rect.bottom + gap,
+    placement: hasRoomAbove ? "above" : "below",
+  }
+}

--- a/quartz/components/styles/quoteLink.scss
+++ b/quartz/components/styles/quoteLink.scss
@@ -1,0 +1,121 @@
+.quote-link {
+  position: fixed;
+  z-index: 10;
+  display: grid;
+  width: 2.5rem;
+  height: 2.5rem;
+  padding: 0;
+  place-items: center;
+  appearance: none;
+  border: 1px solid color-mix(in srgb, var(--gray) 54%, transparent);
+  border-radius: 6px;
+  background-color: var(--light);
+  box-shadow: 0 0.25rem 0.75rem color-mix(in srgb, var(--dark) 14%, transparent);
+  color: var(--dark);
+  cursor: pointer;
+  touch-action: manipulation;
+  transform: translate(-50%, -100%);
+  transition:
+    background-color 0.15s ease-out,
+    border-color 0.15s ease-out,
+    color 0.15s ease-out,
+    transform 0.15s ease-out;
+
+  &[data-placement="below"] {
+    transform: translate(-50%, 0);
+  }
+
+  &[hidden] {
+    display: none;
+  }
+
+  &:hover {
+    border-color: var(--secondary);
+    background-color: var(--lightgray);
+    color: var(--secondary);
+  }
+
+  &:active {
+    transform: translate(-50%, -100%) scale(0.96);
+
+    &[data-placement="below"] {
+      transform: translate(-50%, 0) scale(0.96);
+    }
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--secondary);
+    outline-offset: 2px;
+  }
+
+  &:disabled {
+    cursor: wait;
+  }
+
+  &[data-copied] {
+    border-color: var(--secondary);
+    color: var(--secondary);
+  }
+
+  &[data-failed] {
+    border-color: var(--tertiary);
+    color: var(--tertiary);
+  }
+}
+
+.quote-link-icon {
+  width: 1.125rem;
+  height: 1.125rem;
+  fill: currentColor;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 2;
+}
+
+.quote-link-icon-check {
+  display: none;
+  fill: none;
+}
+
+.quote-link[data-copied] {
+  .quote-link-icon-quote {
+    display: none;
+  }
+
+  .quote-link-icon-check {
+    display: initial;
+  }
+}
+
+.quote-link-status {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .quote-link {
+    transition: none;
+
+    &:active {
+      transform: translate(-50%, -100%);
+    }
+
+    &:active[data-placement="below"] {
+      transform: translate(-50%, 0);
+    }
+  }
+}
+
+@media print {
+  .quote-link,
+  .quote-link-status {
+    display: none;
+  }
+}

--- a/quartz/i18n/locales/definition.ts
+++ b/quartz/i18n/locales/definition.ts
@@ -46,6 +46,12 @@ export interface Translation {
       copiedTitle: string
       copiedLabel: string
     }
+    quoteLink?: {
+      title: string
+      copied: string
+      failed: string
+      open: string
+    }
     readLater?: {
       title: string
       trigger: (variables: { count: number }) => string

--- a/quartz/i18n/locales/en-US.ts
+++ b/quartz/i18n/locales/en-US.ts
@@ -43,6 +43,12 @@ export default {
       copiedTitle: "Copied",
       copiedLabel: "Section link copied",
     },
+    quoteLink: {
+      title: "Copy quote link",
+      copied: "Quote link copied",
+      failed: "The browser could not copy this quote",
+      open: "Open this passage",
+    },
     readLater: {
       title: "Read later",
       trigger: ({ count }) => `Read later, ${count} saved`,

--- a/quartz/i18n/locales/zh-CN.ts
+++ b/quartz/i18n/locales/zh-CN.ts
@@ -43,6 +43,12 @@ export default {
       copiedTitle: "已复制",
       copiedLabel: "本节链接已复制",
     },
+    quoteLink: {
+      title: "复制引用链接",
+      copied: "引用链接已复制",
+      failed: "浏览器未能复制这段引用",
+      open: "打开这段原文",
+    },
     readLater: {
       title: "稍后读",
       trigger: ({ count }) => `稍后读，已保存 ${count} 篇`,

--- a/quartz/i18n/locales/zh-TW.ts
+++ b/quartz/i18n/locales/zh-TW.ts
@@ -40,6 +40,12 @@ export default {
       copiedTitle: "已複製",
       copiedLabel: "本節連結已複製",
     },
+    quoteLink: {
+      title: "複製引用連結",
+      copied: "引用連結已複製",
+      failed: "瀏覽器未能複製這段引用",
+      open: "開啟這段原文",
+    },
     readLater: {
       title: "稍後讀",
       trigger: ({ count }) => `稍後讀，已儲存 ${count} 篇`,

--- a/quartz/plugins/emitters/componentResources.test.ts
+++ b/quartz/plugins/emitters/componentResources.test.ts
@@ -21,14 +21,22 @@ describe("componentResources", () => {
       const headingPermalinksIndex = contents.indexOf(
         "componentResources.afterDOMLoaded.push(headingPermalinksScript)",
       )
+      const quoteLinkIndex = contents.indexOf(
+        "componentResources.afterDOMLoaded.push(quoteLinkScript)",
+      )
+      const quoteLinkStyleIndex = contents.indexOf("componentResources.css.push(quoteLinkStyle)")
       const spaBranchIndex = contents.indexOf("if (cfg.enableSPA)")
 
       assert.notEqual(progressIndex, -1)
       assert.notEqual(backToTopIndex, -1)
       assert.notEqual(headingPermalinksIndex, -1)
+      assert.notEqual(quoteLinkIndex, -1)
+      assert.notEqual(quoteLinkStyleIndex, -1)
       assert.ok(progressIndex < spaBranchIndex)
       assert.ok(backToTopIndex < spaBranchIndex)
       assert.ok(headingPermalinksIndex < spaBranchIndex)
+      assert.ok(quoteLinkIndex < spaBranchIndex)
+      assert.ok(quoteLinkStyleIndex < spaBranchIndex)
     })
   })
 

--- a/quartz/plugins/emitters/componentResources.ts
+++ b/quartz/plugins/emitters/componentResources.ts
@@ -7,6 +7,7 @@ import spaRouterScript from "../../components/scripts/spa.inline"
 // @ts-ignore
 import popoverScript from "../../components/scripts/popover.inline"
 import headingPermalinksScript from "../../components/scripts/headingPermalinks.inline"
+import quoteLinkScript from "../../components/scripts/quoteLink.inline"
 import { backToTopScript } from "../../components/scripts/backToTop"
 import baseStyles from "../../styles/base.scss"
 import customStyles from "../../styles/custom.scss"
@@ -16,6 +17,7 @@ import { readLaterScript } from "../../components/scripts/readLater"
 import readLaterStyle from "../../components/styles/readLater.scss"
 import { resumeReadingScript } from "../../components/scripts/resumeReading"
 import resumeReadingStyle from "../../components/styles/resumeReading.scss"
+import quoteLinkStyle from "../../components/styles/quoteLink.scss"
 import { BuildCtx } from "../../util/ctx"
 import { QuartzComponent } from "../../components/types"
 import { normalizeResource } from "../../util/resources"
@@ -92,12 +94,14 @@ function addGlobalPageResources(ctx: BuildCtx, componentResources: ComponentReso
   const cfg = ctx.cfg.configuration
 
   componentResources.afterDOMLoaded.push(headingPermalinksScript)
+  componentResources.afterDOMLoaded.push(quoteLinkScript)
   componentResources.afterDOMLoaded.push(backToTopScript)
   componentResources.afterDOMLoaded.push(readingProgressScript)
   componentResources.afterDOMLoaded.push(readLaterScript)
   componentResources.css.push(readLaterStyle)
   componentResources.afterDOMLoaded.push(resumeReadingScript)
   componentResources.css.push(resumeReadingStyle)
+  componentResources.css.push(quoteLinkStyle)
 
   // popovers
   if (cfg.enablePopovers) {


### PR DESCRIPTION
This builds a compact Quote Link action for selected prose: readers can highlight a short passage and copy a ready-to-share Markdown blockquote whose link opens the exact text through the browser's Text Fragment syntax. It is worth merging because it turns the garden's most reusable ideas into one-click, source-linked quotes without adding storage, network calls, dependencies, or visual clutter.

## Validation

- `node_modules/.bin/tsx --test quartz/components/scripts/quoteLink.test.ts quartz/plugins/emitters/componentResources.test.ts` (10/10 passed)
- `node_modules/.bin/tsc --noEmit` (passed)
- scoped Prettier check for all changed TypeScript/SCSS files (passed)
- `git diff --check` (passed)
- `node quartz/bootstrap-cli.mjs build` (314 Markdown inputs, 1906 emitted files)
- production browser QA at desktop and 375x812: exact Markdown copy, copy failure, Escape, SPA navigation, excluded links/code, length bound, top-edge placement, light/dark themes, reduced motion, and 404 exclusion (passed)
- full `npm test`: 188/189 passed; the unrelated existing theme-switcher test cannot import undeclared `jsdom`

## Impact

- Adds one hidden-until-needed global reader control and its localized English, Simplified Chinese, and Traditional Chinese labels.
- Operates only on 3-280 character plain-text selections in the current article.
- Does not mutate content, use browser storage, or send selection text over the network.

## Rollback

Revert commit `56c610ffaa6f00cd6820bf0acea36e15d11b284d`; no data migration or cleanup is required.

## Blockers

None found in the implementation. The full-suite `jsdom` resolution failure predates and is outside this change. The Netlify deploy preview failed after 8m9s despite the equivalent local production build passing; GitHub exposed no annotations, Netlify's public API returned no failure summary, and its build logs require authenticated Netlify access.
