### PR TITLE
feat(reader): add a mobile article outline

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -188,6 +188,15 @@ Layout rules:
 - **Privacy**: The action uses only the current selection and URL. It does not write content or storage, send requests, or persist selection text.
 - **Motion**: Existing 150ms micro transitions cover color and press feedback. Reduced-motion mode removes scale feedback, and print hides the action.
 
+### MobileOutline
+
+- **Structure**: One fixed 40px list button opens a native modal dialog containing links to the current article's non-transcluded `h2` and `h3` headings. The control is rendered once by `Body` and populated from the live article after navigation.
+- **Placement**: Mobile only, at the bottom inline-start with 16px and safe-area inset support. Its dialog sits above the fixed controls, stays within `100vw - 32px`, uses the existing 6px radius, and is hidden from print.
+- **Eligibility**: Keep the control hidden on desktop, list/404 surfaces, and articles with fewer than two eligible headings. Repeated SPA `nav` and in-place `render` events must replace the prior outline without duplicate nodes or listeners.
+- **States**: Hidden, ready, open, current section, hover, pressed, focus-visible, long-list scrolling, and missing-native-dialog fallback.
+- **Accessibility**: Localize the dialog title and open/close names; use native `dialog` modal behavior for focus containment and Escape; report expanded state on the trigger; mark the current section with `aria-current="location"`; keep every target as a native hash link.
+- **Motion**: Opening and closing are immediate. Existing 150ms color and press transitions apply to controls and links; reduced-motion mode removes the press transform.
+
 ## 6. Motion & Interaction
 
 Motion is quiet utility feedback, not brand theater.

--- a/quartz/components/Body.test.ts
+++ b/quartz/components/Body.test.ts
@@ -26,6 +26,8 @@ describe("Body", () => {
     // Then
     assert.match(html, /aria-label="Reading progress"/)
     assert.match(html, /aria-label="Back to top"/)
+    assert.match(html, /aria-label="Open page outline"/)
+    assert.match(html, />On this page</)
   })
 
   test("localizes the back-to-top label in Simplified Chinese", () => {
@@ -37,6 +39,7 @@ describe("Body", () => {
 
     // Then
     assert.match(html, /aria-label="返回顶部"/)
+    assert.match(html, /aria-label="打开本页大纲"/)
   })
 
   test("localizes the back-to-top label in Traditional Chinese", () => {
@@ -48,6 +51,7 @@ describe("Body", () => {
 
     // Then
     assert.match(html, /aria-label="返回頂部"/)
+    assert.match(html, /aria-label="開啟本頁大綱"/)
   })
 
   test("falls back to English when a locale has no back-to-top label", () => {
@@ -59,5 +63,6 @@ describe("Body", () => {
 
     // Then
     assert.match(html, /aria-label="Back to top"/)
+    assert.match(html, /aria-label="Open page outline"/)
   })
 })

--- a/quartz/components/Body.tsx
+++ b/quartz/components/Body.tsx
@@ -8,6 +8,7 @@ const Body: QuartzComponent = ({ cfg, children }: QuartzComponentProps) => {
     translation.components.readingProgress?.title ?? fallback.components.readingProgress.title
   const backToTopTitle =
     translation.components.backToTop?.title ?? fallback.components.backToTop.title
+  const mobileOutline = translation.components.mobileOutline ?? fallback.components.mobileOutline
 
   return (
     <>
@@ -30,6 +31,65 @@ const Body: QuartzComponent = ({ cfg, children }: QuartzComponentProps) => {
       >
         <span aria-hidden="true">↑</span>
       </button>
+      <div class="mobile-outline" data-mobile-outline="" hidden>
+        <button
+          class="mobile-outline__trigger"
+          type="button"
+          title={mobileOutline.open}
+          aria-label={mobileOutline.open}
+          aria-controls="mobile-outline-dialog"
+          aria-expanded="false"
+          data-mobile-outline-trigger=""
+        >
+          <svg
+            class="mobile-outline__icon"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            aria-hidden="true"
+          >
+            <path d="M8 6h13" />
+            <path d="M8 12h13" />
+            <path d="M8 18h13" />
+            <path d="M3 6h.01" />
+            <path d="M3 12h.01" />
+            <path d="M3 18h.01" />
+          </svg>
+        </button>
+        <dialog
+          class="mobile-outline__dialog"
+          id="mobile-outline-dialog"
+          aria-labelledby="mobile-outline-title"
+          data-mobile-outline-dialog=""
+        >
+          <header class="mobile-outline__header">
+            <h2 id="mobile-outline-title">{mobileOutline.title}</h2>
+            <button
+              class="mobile-outline__close"
+              type="button"
+              title={mobileOutline.close}
+              aria-label={mobileOutline.close}
+              data-mobile-outline-close=""
+            >
+              <svg
+                class="mobile-outline__icon"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                aria-hidden="true"
+              >
+                <path d="M18 6 6 18" />
+                <path d="m6 6 12 12" />
+              </svg>
+            </button>
+          </header>
+          <ol class="mobile-outline__list" data-mobile-outline-list="" />
+        </dialog>
+      </div>
     </>
   )
 }

--- a/quartz/components/scripts/mobileOutline.test.ts
+++ b/quartz/components/scripts/mobileOutline.test.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert"
+import test, { describe } from "node:test"
+import enUs from "../../i18n/locales/en-US"
+import zhCn from "../../i18n/locales/zh-CN"
+import zhTw from "../../i18n/locales/zh-TW"
+import {
+  findActiveMobileOutlineIndex,
+  getMobileOutlineItems,
+  mobileOutlineScript,
+} from "./mobileOutline"
+
+test("mobile-outline browser script compiles", () => {
+  assert.doesNotThrow(() => new Function(mobileOutlineScript))
+})
+
+test("mobile-outline browser script handles navigation and in-place renders", () => {
+  assert.match(mobileOutlineScript, /document\.addEventListener\("nav", initializeMobileOutline\)/)
+  assert.match(
+    mobileOutlineScript,
+    /document\.addEventListener\("render", initializeMobileOutline\)/,
+  )
+  assert.match(mobileOutlineScript, /window\.addCleanup\(cleanupMobileOutline\)/)
+  assert.match(mobileOutlineScript, /items\.length < 2/)
+  assert.match(mobileOutlineScript, /heading\.closest\("\.transclude"\) === null/)
+  assert.match(mobileOutlineScript, /closeButton\.removeEventListener\("click", closeFromButton\)/)
+})
+
+test("mobile-outline labels use the central locale catalog", () => {
+  assert.equal(enUs.components.mobileOutline.open, "Open page outline")
+  assert.equal(zhCn.components.mobileOutline.title, "本页大纲")
+  assert.equal(zhTw.components.mobileOutline.close, "關閉本頁大綱")
+})
+
+describe("mobile-outline items", () => {
+  test("keeps unique, labeled second- and third-level headings", () => {
+    const items = getMobileOutlineItems([
+      { id: "start", textContent: "  Start  ", tagName: "H2", sourceIndex: 0 },
+      { id: "detail", textContent: "Long\n detail", tagName: "h3", sourceIndex: 1 },
+      { id: "start", textContent: "Duplicate", tagName: "H2", sourceIndex: 2 },
+      { id: "missing", textContent: "  ", tagName: "H2", sourceIndex: 3 },
+    ])
+
+    assert.deepEqual(items, [
+      { id: "start", label: "Start", level: 2, sourceIndex: 0 },
+      { id: "detail", label: "Long detail", level: 3, sourceIndex: 1 },
+    ])
+  })
+
+  test("marks the last heading above the reading offset as current", () => {
+    assert.equal(findActiveMobileOutlineIndex([40, 120, 300], 128), 1)
+    assert.equal(findActiveMobileOutlineIndex([200, 400], 128), -1)
+  })
+})

--- a/quartz/components/scripts/mobileOutline.ts
+++ b/quartz/components/scripts/mobileOutline.ts
@@ -1,0 +1,168 @@
+export type MobileOutlineHeading = Readonly<{
+  id: string
+  textContent: string | null
+  tagName: string
+  sourceIndex: number
+}>
+
+export type MobileOutlineItem = Readonly<{
+  id: string
+  label: string
+  level: 2 | 3
+  sourceIndex: number
+}>
+
+export function getMobileOutlineItems(
+  headings: readonly MobileOutlineHeading[],
+): MobileOutlineItem[] {
+  const seenIds = new Set<string>()
+  const items: MobileOutlineItem[] = []
+
+  for (const heading of headings) {
+    const id = heading.id.trim()
+    const label = heading.textContent?.replace(/\s+/g, " ").trim() ?? ""
+    const level = heading.tagName.toUpperCase() === "H3" ? 3 : 2
+    if (!id || !label || seenIds.has(id)) continue
+
+    seenIds.add(id)
+    items.push({ id, label, level, sourceIndex: heading.sourceIndex })
+  }
+
+  return items
+}
+
+export function findActiveMobileOutlineIndex(
+  headingTops: readonly number[],
+  offset: number,
+): number {
+  let activeIndex = -1
+  for (let index = 0; index < headingTops.length; index++) {
+    if (headingTops[index] > offset) break
+    activeIndex = index
+  }
+  return activeIndex
+}
+
+export const mobileOutlineScript = `
+const getMobileOutlineItems = ${getMobileOutlineItems.toString()}
+const findActiveMobileOutlineIndex = ${findActiveMobileOutlineIndex.toString()}
+
+let cleanupCurrentMobileOutline = () => {}
+const cleanupMobileOutline = () => {
+  const cleanup = cleanupCurrentMobileOutline
+  cleanupCurrentMobileOutline = () => {}
+  cleanup()
+}
+
+function initializeMobileOutline() {
+  cleanupMobileOutline()
+
+  const root = document.querySelector("[data-mobile-outline]")
+  const trigger = root?.querySelector("[data-mobile-outline-trigger]")
+  const dialog = root?.querySelector("[data-mobile-outline-dialog]")
+  const closeButton = root?.querySelector("[data-mobile-outline-close]")
+  const list = root?.querySelector("[data-mobile-outline-list]")
+  const articleTitle = document.querySelector("h1.article-title")
+  if (
+    !(root instanceof HTMLElement) ||
+    !(trigger instanceof HTMLButtonElement) ||
+    !(dialog instanceof HTMLDialogElement) ||
+    !(closeButton instanceof HTMLButtonElement) ||
+    !(list instanceof HTMLOListElement) ||
+    articleTitle === null ||
+    typeof dialog.showModal !== "function"
+  ) {
+    return
+  }
+
+  const headingElements = Array.from(
+    document.querySelectorAll(".center > article h2[id], .center > article h3[id]"),
+  ).filter((heading) => heading.closest(".transclude") === null)
+  const items = getMobileOutlineItems(
+    headingElements.map((heading, sourceIndex) => ({
+      id: heading.id,
+      textContent: heading.textContent,
+      tagName: heading.tagName,
+      sourceIndex,
+    })),
+  )
+  if (items.length < 2) return
+
+  const activeHeadings = items.map((item) => headingElements[item.sourceIndex])
+  const links = items.map((item) => {
+    const listItem = document.createElement("li")
+    const link = document.createElement("a")
+    link.className = "mobile-outline__link"
+    link.dataset.level = String(item.level)
+    link.href = \`#\${encodeURIComponent(item.id)}\`
+    link.textContent = item.label
+    link.setAttribute("data-no-popover", "true")
+    listItem.append(link)
+    list.append(listItem)
+    return link
+  })
+  root.hidden = false
+
+  let restoreFocusOnClose = true
+  const closeDialog = (restoreFocus) => {
+    if (!dialog.open) return
+    restoreFocusOnClose = restoreFocus
+    dialog.close()
+  }
+  const updateCurrentSection = () => {
+    const headingTops = activeHeadings.map((heading) => heading.getBoundingClientRect().top)
+    const activeIndex = findActiveMobileOutlineIndex(
+      headingTops,
+      Math.min(128, window.innerHeight * 0.2),
+    )
+    links.forEach((link, index) => {
+      if (index === activeIndex) link.setAttribute("aria-current", "location")
+      else link.removeAttribute("aria-current")
+    })
+    return activeIndex
+  }
+  const openDialog = () => {
+    if (dialog.open) return
+    const activeIndex = updateCurrentSection()
+    restoreFocusOnClose = true
+    dialog.showModal()
+    trigger.setAttribute("aria-expanded", "true")
+    ;(links[activeIndex] ?? links[0]).focus()
+  }
+  const handleClose = () => {
+    trigger.setAttribute("aria-expanded", "false")
+    if (restoreFocusOnClose) trigger.focus()
+    restoreFocusOnClose = true
+  }
+  const handleCancel = () => {
+    restoreFocusOnClose = true
+  }
+  const closeFromButton = () => closeDialog(true)
+  const dismissBackdrop = (event) => {
+    if (event.target === dialog) closeDialog(true)
+  }
+
+  trigger.addEventListener("click", openDialog)
+  closeButton.addEventListener("click", closeFromButton)
+  dialog.addEventListener("close", handleClose)
+  dialog.addEventListener("cancel", handleCancel)
+  dialog.addEventListener("click", dismissBackdrop)
+  links.forEach((link) => link.addEventListener("click", () => closeDialog(false)))
+
+  cleanupCurrentMobileOutline = () => {
+    trigger.removeEventListener("click", openDialog)
+    closeButton.removeEventListener("click", closeFromButton)
+    dialog.removeEventListener("close", handleClose)
+    dialog.removeEventListener("cancel", handleCancel)
+    dialog.removeEventListener("click", dismissBackdrop)
+    if (dialog.open) dialog.close()
+    trigger.setAttribute("aria-expanded", "false")
+    list.replaceChildren()
+    root.hidden = true
+  }
+  window.addCleanup(cleanupMobileOutline)
+}
+
+document.addEventListener("nav", initializeMobileOutline)
+document.addEventListener("render", initializeMobileOutline)
+`

--- a/quartz/components/styles/mobileOutline.scss
+++ b/quartz/components/styles/mobileOutline.scss
@@ -1,0 +1,178 @@
+@use "../../styles/variables.scss" as *;
+
+.mobile-outline {
+  display: none;
+}
+
+@media all and ($mobile) {
+  .mobile-outline:not([hidden]) {
+    display: block;
+  }
+}
+
+.mobile-outline__trigger,
+.mobile-outline__close {
+  appearance: none;
+  box-sizing: border-box;
+  display: grid;
+  padding: 0;
+  place-items: center;
+  border: 1px solid color-mix(in srgb, var(--gray) 54%, transparent);
+  background-color: var(--light);
+  color: var(--dark);
+  font: inherit;
+  cursor: pointer;
+  touch-action: manipulation;
+  user-select: none;
+  transition:
+    background-color 0.15s ease-out,
+    color 0.15s ease-out,
+    transform 0.15s ease-out;
+
+  @media (hover: hover) and (pointer: fine) {
+    &:hover {
+      border-color: var(--secondary);
+      background-color: var(--lightgray);
+      color: var(--secondary);
+    }
+  }
+
+  &:active {
+    transform: scale(0.93);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--secondary);
+    outline-offset: 2px;
+  }
+}
+
+.mobile-outline__trigger {
+  position: fixed;
+  z-index: 4;
+  inset-block-end: max(1rem, env(safe-area-inset-bottom));
+  inset-inline-start: max(1rem, env(safe-area-inset-left));
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 50%;
+}
+
+.mobile-outline__icon {
+  width: 1.125rem;
+  height: 1.125rem;
+}
+
+.mobile-outline__dialog {
+  position: fixed;
+  z-index: 5;
+  inset: auto 1rem max(4.25rem, calc(4.25rem + env(safe-area-inset-bottom))) 1rem;
+  box-sizing: border-box;
+  width: min(22rem, calc(100vw - 2rem));
+  max-height: min(70dvh, 32rem);
+  margin: 0 auto;
+  padding: 0.75rem;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, var(--gray) 54%, transparent);
+  border-radius: 6px;
+  background-color: var(--light);
+  color: var(--darkgray);
+
+  &[open] {
+    display: flex;
+    flex-direction: column;
+  }
+
+  &::backdrop {
+    background-color: color-mix(in srgb, var(--dark) 24%, transparent);
+  }
+}
+
+.mobile-outline__header {
+  display: flex;
+  min-height: 2.5rem;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+
+  h2 {
+    margin: 0;
+    font-size: 1rem;
+    letter-spacing: 0;
+    line-height: 1.25;
+  }
+}
+
+.mobile-outline__close {
+  width: 2.5rem;
+  height: 2.5rem;
+  flex: 0 0 2.5rem;
+  border-radius: 6px;
+}
+
+.mobile-outline__list {
+  margin: 0.5rem 0 0;
+  padding: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  list-style: none;
+
+  > li {
+    margin: 0;
+  }
+}
+
+.mobile-outline__link {
+  display: block;
+  padding: 0.625rem 0.75rem;
+  border-radius: 4px;
+  color: var(--darkgray);
+  overflow-wrap: anywhere;
+  line-height: 1.35;
+  text-decoration: none;
+  transition:
+    background-color 0.15s ease-out,
+    color 0.15s ease-out;
+
+  &[data-level="3"] {
+    padding-inline-start: 1.5rem;
+    color: var(--gray);
+    font-size: 0.925rem;
+  }
+
+  &[aria-current="location"] {
+    background-color: var(--highlight);
+    color: var(--secondary);
+    box-shadow: inset 3px 0 var(--secondary);
+  }
+
+  @media (hover: hover) and (pointer: fine) {
+    &:hover {
+      background-color: var(--lightgray);
+      color: var(--secondary);
+    }
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--secondary);
+    outline-offset: -2px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mobile-outline__trigger,
+  .mobile-outline__close,
+  .mobile-outline__link {
+    transition: none;
+
+    &:active {
+      transform: none;
+    }
+  }
+}
+
+@media print {
+  .mobile-outline {
+    display: none;
+  }
+}

--- a/quartz/i18n/locales/definition.ts
+++ b/quartz/i18n/locales/definition.ts
@@ -69,6 +69,11 @@ export interface Translation {
       dismiss: string
       region: string
     }
+    mobileOutline?: {
+      title: string
+      open: string
+      close: string
+    }
     explorer: {
       title: string
     }

--- a/quartz/i18n/locales/en-US.ts
+++ b/quartz/i18n/locales/en-US.ts
@@ -66,6 +66,11 @@ export default {
       dismiss: "Dismiss saved reading position",
       region: "Continue reading",
     },
+    mobileOutline: {
+      title: "On this page",
+      open: "Open page outline",
+      close: "Close page outline",
+    },
     explorer: {
       title: "Explorer",
     },

--- a/quartz/i18n/locales/zh-CN.ts
+++ b/quartz/i18n/locales/zh-CN.ts
@@ -66,6 +66,11 @@ export default {
       dismiss: "忽略保存的阅读位置",
       region: "继续阅读",
     },
+    mobileOutline: {
+      title: "本页大纲",
+      open: "打开本页大纲",
+      close: "关闭本页大纲",
+    },
     explorer: {
       title: "探索",
     },

--- a/quartz/i18n/locales/zh-TW.ts
+++ b/quartz/i18n/locales/zh-TW.ts
@@ -63,6 +63,11 @@ export default {
       dismiss: "忽略儲存的閱讀位置",
       region: "繼續閱讀",
     },
+    mobileOutline: {
+      title: "本頁大綱",
+      open: "開啟本頁大綱",
+      close: "關閉本頁大綱",
+    },
     explorer: {
       title: "探索",
     },

--- a/quartz/plugins/emitters/componentResources.test.ts
+++ b/quartz/plugins/emitters/componentResources.test.ts
@@ -83,4 +83,22 @@ describe("componentResources", () => {
       assert.ok(resumeStyleIndex < spaBranchIndex)
     })
   })
+
+  test("includes the mobile outline when SPA navigation is disabled", () => {
+    const emitterPath = new URL("./componentResources.ts", import.meta.url)
+    const source = readFile(emitterPath, "utf8")
+
+    return source.then((contents) => {
+      const scriptIndex = contents.indexOf(
+        "componentResources.afterDOMLoaded.push(mobileOutlineScript)",
+      )
+      const styleIndex = contents.indexOf("componentResources.css.push(mobileOutlineStyle)")
+      const spaBranchIndex = contents.indexOf("if (cfg.enableSPA)")
+
+      assert.notEqual(scriptIndex, -1)
+      assert.notEqual(styleIndex, -1)
+      assert.ok(scriptIndex < spaBranchIndex)
+      assert.ok(styleIndex < spaBranchIndex)
+    })
+  })
 })

--- a/quartz/plugins/emitters/componentResources.ts
+++ b/quartz/plugins/emitters/componentResources.ts
@@ -18,6 +18,8 @@ import readLaterStyle from "../../components/styles/readLater.scss"
 import { resumeReadingScript } from "../../components/scripts/resumeReading"
 import resumeReadingStyle from "../../components/styles/resumeReading.scss"
 import quoteLinkStyle from "../../components/styles/quoteLink.scss"
+import { mobileOutlineScript } from "../../components/scripts/mobileOutline"
+import mobileOutlineStyle from "../../components/styles/mobileOutline.scss"
 import { BuildCtx } from "../../util/ctx"
 import { QuartzComponent } from "../../components/types"
 import { normalizeResource } from "../../util/resources"
@@ -102,6 +104,8 @@ function addGlobalPageResources(ctx: BuildCtx, componentResources: ComponentReso
   componentResources.afterDOMLoaded.push(resumeReadingScript)
   componentResources.css.push(resumeReadingStyle)
   componentResources.css.push(quoteLinkStyle)
+  componentResources.afterDOMLoaded.push(mobileOutlineScript)
+  componentResources.css.push(mobileOutlineStyle)
 
   // popovers
   if (cfg.enablePopovers) {


### PR DESCRIPTION
Built a mobile-only article outline that turns each long note's real H2/H3 structure into a compact, localized modal navigator with current-section highlighting and native hash links. The garden already has a desktop table of contents, so giving phone readers the same fast orientation without adding permanent page chrome feels both useful and delightful enough to merge.

## Validation

- `node_modules/.bin/tsx --test quartz/components/scripts/mobileOutline.test.ts quartz/components/Body.test.ts quartz/plugins/emitters/componentResources.test.ts` (12/12 passed)
- `node_modules/.bin/tsc --noEmit` (passed)
- Scoped Prettier check for every changed code/style file (passed)
- `git diff --check` (passed)
- Production `node quartz/bootstrap-cli.mjs build` (passed: 314 Markdown inputs, 1906 outputs)
- Full suite: 186/187 passed; the only failure is the existing theme-switcher test importing undeclared `jsdom`
- Real Chromium QA at 320x568, 375x812, 800x900, 801x900, and 1280x900 covered open/close, Escape and focus restoration, H2/H3 hierarchy, active-section focus, hash navigation, long-list scrolling, 404/short-page hiding, repeated render and SPA cleanup, light/dark themes, reduced motion, and horizontal overflow

## External Checks

Netlify's deploy-preview and its header, pages, and redirect derivatives failed together after about 1m27s for deploy `6a89eadeac20fb0008285b94`. GitHub exposed zero annotations; Netlify's public deploy API reports `state: error` with `error_message: null`, and the unauthenticated build endpoint returns HTTP 401. The exact-SHA local production build passed, so no deployment configuration or credentials were changed.

## Impact

- Adds one dependency-free reader script, one focused style, tests, localized English/Simplified Chinese/Traditional Chinese labels, server-rendered control markup, resource registration, and the design contract
- Appears only at widths up to 800px and only when a normal article has at least two labeled, non-transcluded H2/H3 headings
- Adds no dependency, content, configuration, storage, analytics, network request, CI, deployment, permission, secret, or shared refactor

## Rollback

Revert commit `911c879610ff7b71d4cc9a055129c721a9e93940`; the isolated script, style, markup, locale keys, tests, registration, and design entry are fully removable together.

## Known Baseline Risk

The existing SPA still reports unrelated `endsWith` and external resource `querySelectorAll` exceptions on this page, and the production build retains its existing note-properties `eval`, invalid-date, and Google Fonts warnings. The new outline is emitted as a separate generated script and remained functional through each of those conditions.
