### PR TITLE
feat(reader): resume unfinished notes

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -171,6 +171,14 @@ Layout rules:
 - **Accessibility**: Chinese and English names include the current saved count. The trigger reports expanded state, the current-note toggle reports pressed state, status changes use a polite live region, Escape restores trigger focus, and every remove action names its note.
 - **Motion**: Open and close are immediate. Existing 150ms micro transitions cover color and press feedback; reduced-motion mode removes the press transform.
 
+### ResumeReading
+
+- **Structure**: A compact inline prompt after the existing reader actions, with one localized continue command and one 40px dismiss icon button. It appears only on a long note when a fresh unfinished position exists for that exact path.
+- **Behavior**: Save progress between 15% and 90% after scrolling pauses. Returning near the top never jumps automatically; the reader explicitly chooses whether to resume. Heading fragments and already-restored browser positions take priority over the prompt.
+- **Storage**: Keep at most 20 path-and-progress entries in `localStorage` for 30 days. Entries contain no note text, title, account data, cookies, analytics, or external requests. Dismissing a prompt removes that note's saved position.
+- **Accessibility**: The prompt is a named complementary region, both controls use localized accessible names, focus remains explicit when the prompt is removed, and the continue action focuses the article before scrolling.
+- **Motion**: Resume uses smooth scrolling only when motion is allowed. Hover, focus, and press feedback follow the existing 150ms reader-control contract; reduced-motion mode removes transitions and spatial press feedback.
+
 ## 6. Motion & Interaction
 
 Motion is quiet utility feedback, not brand theater.

--- a/quartz/components/renderPage.tsx
+++ b/quartz/components/renderPage.tsx
@@ -365,6 +365,8 @@ export function renderPage(
   const headingPermalink = i18n(pageLocale).components.headingPermalink ?? fallbackHeadingPermalink
   const fallbackReadLater = TRANSLATIONS[defaultTranslation].components.readLater
   const readLater = i18n(pageLocale).components.readLater ?? fallbackReadLater
+  const fallbackResumeReading = TRANSLATIONS[defaultTranslation].components.resumeReading
+  const resumeReading = i18n(pageLocale).components.resumeReading ?? fallbackResumeReading
   // During local dev (--serve), the dev server serves from root without the
   // baseUrl subpath, so basePath must be empty to avoid broken links.
   const basePath =
@@ -390,6 +392,9 @@ export function renderPage(
         data-read-later-saved={readLater.saved}
         data-read-later-removed={readLater.removed}
         data-read-later-failed={readLater.failed}
+        data-resume-reading-continue={resumeReading.continueFrom}
+        data-resume-reading-dismiss={resumeReading.dismiss}
+        data-resume-reading-region={resumeReading.region}
       >
         {frame.css && <style dangerouslySetInnerHTML={{ __html: frame.css }} />}
         <div id="quartz-root" class="page" data-frame={frame.name}>

--- a/quartz/components/scripts/resumeReading.test.ts
+++ b/quartz/components/scripts/resumeReading.test.ts
@@ -1,0 +1,129 @@
+import assert from "node:assert"
+import test, { describe } from "node:test"
+import enUs from "../../i18n/locales/en-US"
+import zhCn from "../../i18n/locales/zh-CN"
+import zhTw from "../../i18n/locales/zh-TW"
+import {
+  calculateResumeReadingProgress,
+  calculateResumeReadingTarget,
+  resumeReadingScript,
+} from "./resumeReading"
+import {
+  RESUME_READING_LIMIT,
+  RESUME_READING_MAX_AGE_MS,
+  parseResumeReadingEntries,
+  updateResumeReadingEntries,
+  type ResumeReadingEntry,
+} from "./resumeReadingStorage"
+
+test("resume-reading browser script compiles", () => {
+  assert.doesNotThrow(() => new Function(resumeReadingScript))
+})
+
+test("resume-reading browser script handles Quartz lifecycle events", () => {
+  assert.match(resumeReadingScript, /document\.addEventListener\("nav", initializeResumeReading\)/)
+  assert.match(
+    resumeReadingScript,
+    /document\.addEventListener\("render", initializeResumeReading\)/,
+  )
+  assert.match(resumeReadingScript, /window\.addCleanup\(cleanupResumeReading\)/)
+  assert.match(resumeReadingScript, /location\.hash\.length === 0/)
+  assert.match(resumeReadingScript, /window\.matchMedia\("\(prefers-reduced-motion: reduce\)"\)/)
+  assert.match(resumeReadingScript, /if \(!hasUserScrollIntent\) return/)
+  assert.match(resumeReadingScript, /window\.addEventListener\("wheel", markUserScrollIntent/)
+  assert.match(resumeReadingScript, /window\.addEventListener\("touchmove", markUserScrollIntent/)
+  assert.match(
+    resumeReadingScript,
+    /window\.addEventListener\("keydown", markKeyboardScrollIntent\)/,
+  )
+  assert.match(resumeReadingScript, /restoreTimer = window\.setTimeout/)
+  assert.match(resumeReadingScript, /if \(hasUserScrollIntent\) return/)
+  assert.match(resumeReadingScript, /if \(restorePass < 3\)/)
+})
+
+test("resume-reading labels use the central locale catalog", () => {
+  assert.equal(enUs.components.resumeReading.continueFrom, "Continue from {percent}%")
+  assert.equal(zhCn.components.resumeReading.continueFrom, "从 {percent}% 继续阅读")
+  assert.equal(zhTw.components.resumeReading.continueFrom, "從 {percent}% 繼續閱讀")
+})
+
+describe("reading position", () => {
+  test("calculates and clamps page progress", () => {
+    assert.equal(calculateResumeReadingProgress(300, 1_000, 400), 0.5)
+    assert.equal(calculateResumeReadingProgress(-20, 1_000, 400), 0)
+    assert.equal(calculateResumeReadingProgress(900, 1_000, 400), 1)
+    assert.equal(calculateResumeReadingProgress(0, 400, 400), 1)
+  })
+
+  test("maps stored progress onto the current page height", () => {
+    assert.equal(calculateResumeReadingTarget(0.5, 1_000, 400), 300)
+    assert.equal(calculateResumeReadingTarget(2, 1_000, 400), 600)
+    assert.equal(calculateResumeReadingTarget(0.5, 300, 400), 0)
+  })
+})
+
+describe("resume-reading storage", () => {
+  const now = 1_800_000_000_000
+
+  test("keeps safe, unfinished, fresh positions once per path", () => {
+    const stored = JSON.stringify([
+      { path: "/note", progress: 0.6, updatedAt: now - 10 },
+      { path: "/note", progress: 0.4, updatedAt: now - 20 },
+      { path: "//evil.example", progress: 0.5, updatedAt: now - 10 },
+      { path: "/complete", progress: 0.95, updatedAt: now - 10 },
+      { path: "/barely-started", progress: 0.05, updatedAt: now - 10 },
+      { path: "/stale", progress: 0.5, updatedAt: now - RESUME_READING_MAX_AGE_MS - 1 },
+      { path: "/future", progress: 0.5, updatedAt: now + 1 },
+    ])
+
+    assert.deepEqual(parseResumeReadingEntries(stored, now), [
+      { path: "/note", progress: 0.6, updatedAt: now - 10 },
+    ])
+  })
+
+  test("returns an empty list for malformed JSON", () => {
+    assert.deepEqual(parseResumeReadingEntries("[{", now), [])
+    assert.deepEqual(parseResumeReadingEntries("{}", now), [])
+  })
+
+  test("adds a mid-article position to the front", () => {
+    const existing: readonly ResumeReadingEntry[] = [
+      { path: "/older", progress: 0.4, updatedAt: now - 1 },
+    ]
+    const current = { path: "/current", progress: 0.55, updatedAt: now }
+
+    assert.deepEqual(updateResumeReadingEntries(existing, current), [current, ...existing])
+  })
+
+  test("removes positions at the beginning or end of an article", () => {
+    const existing: readonly ResumeReadingEntry[] = [
+      { path: "/current", progress: 0.55, updatedAt: now - 1 },
+      { path: "/other", progress: 0.4, updatedAt: now - 2 },
+    ]
+
+    assert.deepEqual(
+      updateResumeReadingEntries(existing, { path: "/current", progress: 0.05, updatedAt: now }),
+      [existing[1]],
+    )
+    assert.deepEqual(
+      updateResumeReadingEntries(existing, { path: "/current", progress: 0.95, updatedAt: now }),
+      [existing[1]],
+    )
+  })
+
+  test("bounds the list to the most recent entries", () => {
+    const existing: readonly ResumeReadingEntry[] = Array.from(
+      { length: RESUME_READING_LIMIT },
+      (_, index) => ({ path: `/note-${index}`, progress: 0.5, updatedAt: now - index }),
+    )
+    const current = { path: "/current", progress: 0.5, updatedAt: now }
+    const updated = updateResumeReadingEntries(existing, current)
+
+    assert.equal(updated.length, RESUME_READING_LIMIT)
+    assert.deepEqual(updated[0], current)
+    assert.equal(
+      updated.some((entry) => entry.path === "/note-19"),
+      false,
+    )
+  })
+})

--- a/quartz/components/scripts/resumeReading.ts
+++ b/quartz/components/scripts/resumeReading.ts
@@ -1,0 +1,259 @@
+import {
+  RESUME_READING_LIMIT,
+  RESUME_READING_MAX_AGE_MS,
+  RESUME_READING_MAX_PROGRESS,
+  RESUME_READING_MIN_PROGRESS,
+  parseResumeReadingEntries,
+  parseResumeReadingEntry,
+  updateResumeReadingEntries,
+} from "./resumeReadingStorage"
+
+export function calculateResumeReadingProgress(
+  scrollY: number,
+  scrollHeight: number,
+  viewportHeight: number,
+): number {
+  const scrollableHeight = scrollHeight - viewportHeight
+  if (scrollableHeight <= 0) return 1
+
+  return Math.min(1, Math.max(0, scrollY / scrollableHeight))
+}
+
+export function calculateResumeReadingTarget(
+  progress: number,
+  scrollHeight: number,
+  viewportHeight: number,
+): number {
+  return Math.max(0, scrollHeight - viewportHeight) * Math.min(1, Math.max(0, progress))
+}
+
+export const resumeReadingScript = `
+const RESUME_READING_KEY = "dg3.resumeReading.v1"
+const RESUME_READING_LIMIT = ${RESUME_READING_LIMIT}
+const RESUME_READING_MIN_PROGRESS = ${RESUME_READING_MIN_PROGRESS}
+const RESUME_READING_MAX_PROGRESS = ${RESUME_READING_MAX_PROGRESS}
+const RESUME_READING_MAX_AGE_MS = ${RESUME_READING_MAX_AGE_MS}
+const parseResumeReadingEntry = ${parseResumeReadingEntry.toString()}
+const parseResumeReadingEntries = ${parseResumeReadingEntries.toString()}
+const updateResumeReadingEntries = ${updateResumeReadingEntries.toString()}
+const calculateResumeReadingProgress = ${calculateResumeReadingProgress.toString()}
+const calculateResumeReadingTarget = ${calculateResumeReadingTarget.toString()}
+
+function readResumeReadingEntries() {
+  try {
+    return parseResumeReadingEntries(localStorage.getItem(RESUME_READING_KEY), Date.now())
+  } catch (error) {
+    if (error instanceof DOMException) return []
+    throw error
+  }
+}
+
+function writeResumeReadingEntries(entries) {
+  try {
+    if (entries.length === 0) {
+      localStorage.removeItem(RESUME_READING_KEY)
+    } else {
+      localStorage.setItem(RESUME_READING_KEY, JSON.stringify(entries))
+    }
+    return true
+  } catch (error) {
+    if (error instanceof DOMException) return false
+    throw error
+  }
+}
+
+function getResumeReadingLabels() {
+  const {
+    resumeReadingContinue: continueFrom,
+    resumeReadingDismiss: dismiss,
+    resumeReadingRegion: region,
+  } = document.body.dataset
+  if (!continueFrom || !dismiss || !region || !continueFrom.includes("{percent}")) {
+    return undefined
+  }
+
+  return { continueFrom, dismiss, region }
+}
+
+function focusWithoutScrolling(element) {
+  const hadTabIndex = element.hasAttribute("tabindex")
+  if (!hadTabIndex) element.setAttribute("tabindex", "-1")
+  element.focus({ preventScroll: true })
+  if (!hadTabIndex) {
+    element.addEventListener("blur", () => element.removeAttribute("tabindex"), { once: true })
+  }
+}
+
+let cleanupCurrentResumeReading = () => {}
+const cleanupResumeReading = () => {
+  const cleanup = cleanupCurrentResumeReading
+  cleanupCurrentResumeReading = () => {}
+  cleanup()
+}
+
+function initializeResumeReading() {
+  cleanupResumeReading()
+
+  const article = document.querySelector("article.popover-hint")
+  const title = document.querySelector("h1.article-title")
+  const anchor = document.querySelector("[data-read-later-root]") ?? document.querySelector(".content-meta")
+  const labels = getResumeReadingLabels()
+  const now = Date.now()
+  const current = parseResumeReadingEntry({
+    path: location.pathname,
+    progress: RESUME_READING_MIN_PROGRESS,
+    updatedAt: now,
+  })
+  if (article === null || title === null || anchor === null || labels === undefined || current === undefined) {
+    return
+  }
+
+  const path = current.path
+  let entries = readResumeReadingEntries()
+  const stored = entries.find((entry) => entry.path === path)
+  const scrollableHeight = document.documentElement.scrollHeight - window.innerHeight
+  const isLongPage = scrollableHeight >= window.innerHeight * 1.25
+  const startsNearTop = window.scrollY < window.innerHeight * 0.25
+  let prompt
+  let saveTimer
+  let restoreTimer
+  let hasScrolled = false
+  let hasUserScrollIntent = false
+  let initialScrollY = window.scrollY
+
+  const removePrompt = () => {
+    prompt?.remove()
+    prompt = undefined
+  }
+
+  const persistCurrentPosition = () => {
+    saveTimer = undefined
+    if (!hasScrolled) return
+
+    const progress = calculateResumeReadingProgress(
+      window.scrollY,
+      document.documentElement.scrollHeight,
+      window.innerHeight,
+    )
+    entries = updateResumeReadingEntries(entries, { path, progress, updatedAt: Date.now() })
+    writeResumeReadingEntries(entries)
+  }
+
+  const scheduleSave = () => {
+    if (!hasUserScrollIntent) return
+    if (Math.abs(window.scrollY - initialScrollY) > 4) hasScrolled = true
+    if (prompt !== undefined && window.scrollY >= window.innerHeight * 0.25) removePrompt()
+    if (saveTimer !== undefined) window.clearTimeout(saveTimer)
+    saveTimer = window.setTimeout(persistCurrentPosition, 600)
+  }
+
+  const markUserScrollIntent = () => {
+    hasUserScrollIntent = true
+  }
+  const markKeyboardScrollIntent = (event) => {
+    if (
+      !event.altKey &&
+      !event.ctrlKey &&
+      !event.metaKey &&
+      ["ArrowDown", "ArrowUp", "End", "Home", "PageDown", "PageUp", " "].includes(event.key)
+    ) {
+      markUserScrollIntent()
+    }
+  }
+  const markScrollbarScrollIntent = (event) => {
+    if (event.button === 0 && event.clientX >= document.documentElement.clientWidth) {
+      markUserScrollIntent()
+    }
+  }
+
+  const dismissPrompt = () => {
+    entries = updateResumeReadingEntries(entries, { path, progress: 0, updatedAt: Date.now() })
+    writeResumeReadingEntries(entries)
+    focusWithoutScrolling(title)
+    removePrompt()
+  }
+
+  if (stored !== undefined && isLongPage && startsNearTop && location.hash.length === 0) {
+    const root = document.createElement("aside")
+    root.className = "resume-reading"
+    root.setAttribute("aria-label", labels.region)
+    root.setAttribute("data-resume-reading-root", "")
+
+    const continueButton = document.createElement("button")
+    continueButton.type = "button"
+    continueButton.className = "resume-reading-continue"
+    continueButton.textContent = labels.continueFrom.replace(
+      "{percent}",
+      String(Math.round(stored.progress * 100)),
+    )
+
+    const dismissButton = document.createElement("button")
+    dismissButton.type = "button"
+    dismissButton.className = "resume-reading-dismiss"
+    dismissButton.textContent = "\u00d7"
+    dismissButton.title = labels.dismiss
+    dismissButton.setAttribute("aria-label", labels.dismiss)
+
+    continueButton.addEventListener("click", () => {
+      focusWithoutScrolling(article)
+      removePrompt()
+      const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches
+      hasUserScrollIntent = false
+      hasScrolled = false
+      initialScrollY = window.scrollY
+      let restorePass = 0
+      const restorePosition = () => {
+        restoreTimer = undefined
+        if (hasUserScrollIntent) return
+
+        const target = calculateResumeReadingTarget(
+          stored.progress,
+          document.documentElement.scrollHeight,
+          window.innerHeight,
+        )
+        const behavior = !reducedMotion && restorePass === 0 ? "smooth" : "auto"
+        window.scrollTo({ top: target, behavior })
+        restorePass += 1
+        if (restorePass < 3) {
+          restoreTimer = window.setTimeout(restorePosition, restorePass === 1 ? 240 : 600)
+        }
+      }
+      restoreTimer = window.setTimeout(restorePosition, 120)
+    })
+    dismissButton.addEventListener("click", dismissPrompt)
+    root.append(continueButton, dismissButton)
+    anchor.insertAdjacentElement("afterend", root)
+    prompt = root
+  }
+
+  const saveWhenHidden = () => {
+    if (document.visibilityState === "hidden") persistCurrentPosition()
+  }
+  const cleanup = () => {
+    window.removeEventListener("scroll", scheduleSave)
+    window.removeEventListener("wheel", markUserScrollIntent)
+    window.removeEventListener("touchmove", markUserScrollIntent)
+    window.removeEventListener("keydown", markKeyboardScrollIntent)
+    window.removeEventListener("pointerdown", markScrollbarScrollIntent)
+    window.removeEventListener("pagehide", persistCurrentPosition)
+    document.removeEventListener("visibilitychange", saveWhenHidden)
+    if (saveTimer !== undefined) window.clearTimeout(saveTimer)
+    if (restoreTimer !== undefined) window.clearTimeout(restoreTimer)
+    persistCurrentPosition()
+    removePrompt()
+  }
+
+  window.addEventListener("scroll", scheduleSave, { passive: true })
+  window.addEventListener("wheel", markUserScrollIntent, { passive: true })
+  window.addEventListener("touchmove", markUserScrollIntent, { passive: true })
+  window.addEventListener("keydown", markKeyboardScrollIntent)
+  window.addEventListener("pointerdown", markScrollbarScrollIntent)
+  window.addEventListener("pagehide", persistCurrentPosition)
+  document.addEventListener("visibilitychange", saveWhenHidden)
+  cleanupCurrentResumeReading = cleanup
+  window.addCleanup(cleanupResumeReading)
+}
+
+document.addEventListener("nav", initializeResumeReading)
+document.addEventListener("render", initializeResumeReading)
+`

--- a/quartz/components/scripts/resumeReadingStorage.ts
+++ b/quartz/components/scripts/resumeReadingStorage.ts
@@ -1,0 +1,102 @@
+export const RESUME_READING_LIMIT = 20
+export const RESUME_READING_MIN_PROGRESS = 0.15
+export const RESUME_READING_MAX_PROGRESS = 0.9
+export const RESUME_READING_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1_000
+
+export type ResumeReadingEntry = Readonly<{
+  path: string
+  progress: number
+  updatedAt: number
+}>
+
+export function parseResumeReadingEntry(candidate: unknown): ResumeReadingEntry | undefined {
+  if (typeof candidate !== "object" || candidate === null) return undefined
+
+  const path: unknown = Reflect.get(candidate, "path")
+  const progress: unknown = Reflect.get(candidate, "progress")
+  const updatedAt: unknown = Reflect.get(candidate, "updatedAt")
+  if (
+    typeof path !== "string" ||
+    path.length > 2048 ||
+    !path.startsWith("/") ||
+    path.startsWith("//") ||
+    path.includes("\\") ||
+    path.includes("?") ||
+    path.includes("#") ||
+    /[\u0000-\u0020\u007f]/u.test(path) ||
+    typeof progress !== "number" ||
+    !Number.isFinite(progress) ||
+    progress < 0 ||
+    progress > 1 ||
+    typeof updatedAt !== "number" ||
+    !Number.isSafeInteger(updatedAt) ||
+    updatedAt < 0
+  ) {
+    return undefined
+  }
+
+  let resolvedPath: URL
+  try {
+    resolvedPath = new URL(path, "https://resume-reading.invalid/")
+  } catch {
+    return undefined
+  }
+  if (resolvedPath.origin !== "https://resume-reading.invalid") return undefined
+
+  return { path, progress, updatedAt }
+}
+
+export function parseResumeReadingEntries(
+  raw: string | null,
+  now = Date.now(),
+): readonly ResumeReadingEntry[] {
+  if (raw === null) return []
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return []
+  }
+  if (!Array.isArray(parsed)) return []
+
+  const entries: ResumeReadingEntry[] = []
+  const paths = new Set<string>()
+  for (const candidate of parsed) {
+    const entry = parseResumeReadingEntry(candidate)
+    if (
+      entry === undefined ||
+      entry.progress < RESUME_READING_MIN_PROGRESS ||
+      entry.progress > RESUME_READING_MAX_PROGRESS ||
+      entry.updatedAt > now ||
+      now - entry.updatedAt > RESUME_READING_MAX_AGE_MS ||
+      paths.has(entry.path)
+    ) {
+      continue
+    }
+
+    entries.push(entry)
+    paths.add(entry.path)
+    if (entries.length === RESUME_READING_LIMIT) break
+  }
+
+  return entries
+}
+
+export function updateResumeReadingEntries(
+  entries: readonly ResumeReadingEntry[],
+  candidate: ResumeReadingEntry,
+): readonly ResumeReadingEntry[] {
+  const entry = parseResumeReadingEntry(candidate)
+  if (entry === undefined) return entries
+
+  const remaining = entries.filter((current) => current.path !== entry.path)
+  if (
+    entry.progress < RESUME_READING_MIN_PROGRESS ||
+    entry.progress > RESUME_READING_MAX_PROGRESS
+  ) {
+    return remaining
+  }
+
+  return [entry, ...remaining].slice(0, RESUME_READING_LIMIT)
+}

--- a/quartz/components/styles/resumeReading.scss
+++ b/quartz/components/styles/resumeReading.scss
@@ -1,0 +1,83 @@
+.resume-reading {
+  display: flex;
+  width: fit-content;
+  max-width: 100%;
+  min-height: 2.5rem;
+  margin-block: -0.5rem 1rem;
+  margin-inline: auto 0;
+  align-items: stretch;
+  justify-content: flex-end;
+  gap: 0.25rem;
+}
+
+.resume-reading-continue,
+.resume-reading-dismiss {
+  appearance: none;
+  box-sizing: border-box;
+  min-height: 2.5rem;
+  border: 1px solid color-mix(in srgb, var(--gray) 54%, transparent);
+  border-radius: 6px;
+  background-color: var(--light);
+  color: var(--dark);
+  font: inherit;
+  cursor: pointer;
+  touch-action: manipulation;
+  transition:
+    background-color 0.15s ease-out,
+    border-color 0.15s ease-out,
+    color 0.15s ease-out,
+    transform 0.15s ease-out;
+
+  @media (hover: hover) and (pointer: fine) {
+    &:hover {
+      border-color: var(--secondary);
+      background-color: var(--lightgray);
+      color: var(--secondary);
+    }
+  }
+
+  &:active {
+    transform: scale(0.96);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--secondary);
+    outline-offset: 2px;
+  }
+}
+
+.resume-reading-continue {
+  max-width: calc(100vw - 4.75rem);
+  padding: 0.5rem 0.75rem;
+  overflow-wrap: anywhere;
+  line-height: 1.35;
+  text-align: start;
+}
+
+.resume-reading-dismiss {
+  display: grid;
+  width: 2.5rem;
+  min-width: 2.5rem;
+  padding: 0;
+  place-items: center;
+  font-family: var(--codeFont);
+  font-size: 1.125rem;
+  line-height: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .resume-reading-continue,
+  .resume-reading-dismiss {
+    transition: none;
+
+    &:active {
+      transform: none;
+    }
+  }
+}
+
+@media print {
+  .resume-reading {
+    display: none;
+  }
+}

--- a/quartz/i18n/locales/definition.ts
+++ b/quartz/i18n/locales/definition.ts
@@ -58,6 +58,11 @@ export interface Translation {
       removed: string
       failed: string
     }
+    resumeReading?: {
+      continueFrom: string
+      dismiss: string
+      region: string
+    }
     explorer: {
       title: string
     }

--- a/quartz/i18n/locales/en-US.ts
+++ b/quartz/i18n/locales/en-US.ts
@@ -55,6 +55,11 @@ export default {
       removed: "Removed from read later",
       failed: "The browser could not save this change",
     },
+    resumeReading: {
+      continueFrom: "Continue from {percent}%",
+      dismiss: "Dismiss saved reading position",
+      region: "Continue reading",
+    },
     explorer: {
       title: "Explorer",
     },

--- a/quartz/i18n/locales/zh-CN.ts
+++ b/quartz/i18n/locales/zh-CN.ts
@@ -55,6 +55,11 @@ export default {
       removed: "已从稍后读移除",
       failed: "浏览器未能保存更改",
     },
+    resumeReading: {
+      continueFrom: "从 {percent}% 继续阅读",
+      dismiss: "忽略保存的阅读位置",
+      region: "继续阅读",
+    },
     explorer: {
       title: "探索",
     },

--- a/quartz/i18n/locales/zh-TW.ts
+++ b/quartz/i18n/locales/zh-TW.ts
@@ -52,6 +52,11 @@ export default {
       removed: "已從稍後讀移除",
       failed: "瀏覽器未能儲存變更",
     },
+    resumeReading: {
+      continueFrom: "從 {percent}% 繼續閱讀",
+      dismiss: "忽略儲存的閱讀位置",
+      region: "繼續閱讀",
+    },
     explorer: {
       title: "探索",
     },

--- a/quartz/plugins/emitters/componentResources.test.ts
+++ b/quartz/plugins/emitters/componentResources.test.ts
@@ -53,4 +53,26 @@ describe("componentResources", () => {
       assert.ok(readLaterStyleIndex < spaBranchIndex)
     })
   })
+
+  test("includes resume reading when SPA navigation is disabled", () => {
+    // Given
+    const emitterPath = new URL("./componentResources.ts", import.meta.url)
+
+    // When
+    const source = readFile(emitterPath, "utf8")
+
+    // Then
+    return source.then((contents) => {
+      const resumeIndex = contents.indexOf(
+        "componentResources.afterDOMLoaded.push(resumeReadingScript)",
+      )
+      const resumeStyleIndex = contents.indexOf("componentResources.css.push(resumeReadingStyle)")
+      const spaBranchIndex = contents.indexOf("if (cfg.enableSPA)")
+
+      assert.notEqual(resumeIndex, -1)
+      assert.notEqual(resumeStyleIndex, -1)
+      assert.ok(resumeIndex < spaBranchIndex)
+      assert.ok(resumeStyleIndex < spaBranchIndex)
+    })
+  })
 })

--- a/quartz/plugins/emitters/componentResources.ts
+++ b/quartz/plugins/emitters/componentResources.ts
@@ -14,6 +14,8 @@ import popoverStyle from "../../components/styles/popover.scss"
 import { readingProgressScript } from "../../components/scripts/readingProgress"
 import { readLaterScript } from "../../components/scripts/readLater"
 import readLaterStyle from "../../components/styles/readLater.scss"
+import { resumeReadingScript } from "../../components/scripts/resumeReading"
+import resumeReadingStyle from "../../components/styles/resumeReading.scss"
 import { BuildCtx } from "../../util/ctx"
 import { QuartzComponent } from "../../components/types"
 import { normalizeResource } from "../../util/resources"
@@ -94,6 +96,8 @@ function addGlobalPageResources(ctx: BuildCtx, componentResources: ComponentReso
   componentResources.afterDOMLoaded.push(readingProgressScript)
   componentResources.afterDOMLoaded.push(readLaterScript)
   componentResources.css.push(readLaterStyle)
+  componentResources.afterDOMLoaded.push(resumeReadingScript)
+  componentResources.css.push(resumeReadingStyle)
 
   // popovers
   if (cfg.enablePopovers) {


### PR DESCRIPTION
Long notes now remember a reader's unfinished position and offer a compact, localized “continue from N%” prompt when they return near the top. It feels worth merging because it makes a large personal garden much easier to revisit without taking control away from the reader: the page never jumps automatically, dismissal is explicit, and the small local-only record contains no note text or account data.

## Validation

- Exact commit: `65b2d72c38ec5089bc0e66f781f9decf2137f15a`
- Focused tests: 26/26 passed (`resumeReading`, `componentResources`, `renderPage`)
- TypeScript: `tsc --noEmit` passed
- Formatting and patch integrity: scoped Prettier check and `git diff HEAD^ --check` passed
- Production build: 314 inputs emitted 1,906 files successfully
- Full suite: 191/192 passed; the sole failure is the existing `themeSwitcherScript.test.ts` import of undeclared `jsdom`
- Real Chrome QA: verified wheel-based saving and return prompt, dark desktop and 390px mobile layouts, reduced motion, click-to-resume at 52.005%, article focus, dismissal, and hash suppression
- Change evidence: baseline and accepted recordings plus desktop/mobile screenshots are retained under the automation evidence directory

## Impact

- Stores at most 20 path/progress/timestamp entries in `localStorage` for 30 days; entries outside 15%–90% are removed
- Adds no dependency, content change, network request, analytics, account data, or automatic scrolling
- Handles Quartz `nav` and `render` lifecycles and ignores layout shifts until real scroll intent is observed
- Adds localized labels for English, Simplified Chinese, and Traditional Chinese with the existing English fallback for other locales

## Rollback

Revert `65b2d72c38ec5089bc0e66f781f9decf2137f15a`. Existing `dg3.resumeReading.v1` browser data is inert without the script and can be removed independently if desired.

## Known risks

- Netlify's preview and three rule checks failed at the deploy-service level. GitHub reports no annotations, the public deploy metadata has no error message, and the same service state is present on Happy Hour PRs #16–#19; the exact commit's local production build passed.
- Several open Happy Hour PRs touch the same shared resource and locale registration files, so merge-order conflicts may need a small mechanical resolution.
- Existing build warnings remain unchanged: the note-properties direct `eval`, one invalid content date, and a Google Fonts HTTP 400 response.
