### PR TITLE
feat(reader): add a session reading trail

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -251,6 +251,15 @@ Layout rules:
 - **Accessibility**: Use native buttons with localized names, visible focus rings, disabled boundary states, a polite value/status region, Escape and outside-click dismissal, and focus restoration. Cross-tab changes update the rendered article without navigation.
 - **Motion**: Reuse the 150ms reader-control hover and press feedback. Reduced-motion mode removes spatial feedback, and print hides the control while preserving the selected article scale.
 
+### ReadingTrail
+
+- **Structure**: One 40px history action joins the existing reader action row. It opens a 320px anchored panel listing the notes visited immediately before the current note, newest first, with a bounded path hint for duplicate titles.
+- **Behavior**: Record eligible titled pages after `nav` and in-place `render` events. Revisiting a note moves it to the front, so a reader can retrace a nonlinear wander without duplicate entries. Opening the trail closes the overlapping `ReadLater` panel.
+- **Storage**: Keep at most 8 safe path, title, and visit-time entries in `sessionStorage`; the trail disappears with the tab session. No note text, account data, cookies, analytics, content writes, or external requests.
+- **States**: Empty, populated, open, cleared, storage fallback, hover, pressed, focus-visible, long-list scrolling, and repeated SPA initialization without duplicate nodes or listeners.
+- **Accessibility**: The localized trigger reports the number of prior notes; the panel has a localized heading; every entry is a native internal link; Escape and the close action restore trigger focus; clear is named and disabled when the list is empty.
+- **Motion**: Open and close are immediate. Existing 150ms color and press transitions apply to controls; reduced-motion mode removes press transforms, and print hides the trail.
+
 ## 6. Motion & Interaction
 
 Motion is quiet utility feedback, not brand theater.

--- a/quartz/components/renderPage.test.ts
+++ b/quartz/components/renderPage.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert"
 import {
   pageResources,
   readLaterTriggerLabels,
+  readingTrailTriggerLabels,
   renderTranscludes,
   resolvePageLocale,
 } from "./renderPage"
@@ -75,6 +76,14 @@ test("readLaterTriggerLabels evaluates bounded counts through the locale functio
   assert.equal(labels[1], "One saved note")
   assert.equal(labels[20], "20 saved notes")
   assert.equal(labels.length, 21)
+})
+
+test("readingTrailTriggerLabels evaluates every bounded count", () => {
+  const labels = readingTrailTriggerLabels(({ count }) => `${count} previous`)
+
+  assert.equal(labels[0], "0 previous")
+  assert.equal(labels[8], "8 previous")
+  assert.equal(labels.length, 9)
 })
 
 function makeComponentData(

--- a/quartz/components/renderPage.tsx
+++ b/quartz/components/renderPage.tsx
@@ -17,6 +17,7 @@ import { resolveFrame } from "./frames"
 import type { TreeTransform } from "../plugins/types"
 import type { BuildCtx } from "../util/ctx"
 import { READ_LATER_LIMIT } from "./scripts/readLaterStorage"
+import { READING_TRAIL_LIMIT } from "./scripts/readingTrailStorage"
 
 interface RenderComponents {
   head: QuartzComponent
@@ -51,6 +52,12 @@ export function readLaterTriggerLabels(
   trigger: (variables: { count: number }) => string,
 ): readonly string[] {
   return Array.from({ length: READ_LATER_LIMIT + 1 }, (_, count) => trigger({ count }))
+}
+
+export function readingTrailTriggerLabels(
+  trigger: (variables: { count: number }) => string,
+): readonly string[] {
+  return Array.from({ length: READING_TRAIL_LIMIT + 1 }, (_, count) => trigger({ count }))
 }
 
 export function pageResources(
@@ -394,6 +401,8 @@ export function renderPage(
   const codeFolding = i18n(pageLocale).components.codeFolding ?? fallbackCodeFolding
   const fallbackReadingComfort = TRANSLATIONS[defaultTranslation].components.readingComfort
   const readingComfort = i18n(pageLocale).components.readingComfort ?? fallbackReadingComfort
+  const fallbackReadingTrail = TRANSLATIONS[defaultTranslation].components.readingTrail
+  const readingTrail = i18n(pageLocale).components.readingTrail ?? fallbackReadingTrail
   // During local dev (--serve), the dev server serves from root without the
   // baseUrl subpath, so basePath must be empty to avoid broken links.
   const basePath =
@@ -438,6 +447,13 @@ export function renderPage(
         data-note-share-copy-markdown={noteShare.copyMarkdown}
         data-note-share-markdown-copied={noteShare.markdownCopied}
         data-note-share-markdown-failed={noteShare.markdownFailed}
+        data-reading-trail-title={readingTrail.title}
+        data-reading-trail-trigger={JSON.stringify(readingTrailTriggerLabels(readingTrail.trigger))}
+        data-reading-trail-close={readingTrail.close}
+        data-reading-trail-clear={readingTrail.clear}
+        data-reading-trail-empty={readingTrail.empty}
+        data-reading-trail-cleared={readingTrail.cleared}
+        data-reading-trail-failed={readingTrail.failed}
         data-search-no-results={searchNoResults}
         data-search-no-results-hint={searchNoResultsHint}
         data-search-result-list={searchResultList}

--- a/quartz/components/scripts/readingTrail.test.ts
+++ b/quartz/components/scripts/readingTrail.test.ts
@@ -1,0 +1,83 @@
+import assert from "node:assert"
+import test, { describe } from "node:test"
+import enUs from "../../i18n/locales/en-US"
+import zhCn from "../../i18n/locales/zh-CN"
+import zhTw from "../../i18n/locales/zh-TW"
+import { readingTrailScript } from "./readingTrail"
+import {
+  READING_TRAIL_LIMIT,
+  parseReadingTrailEntries,
+  recordReadingTrailEntry,
+  type ReadingTrailEntry,
+} from "./readingTrailStorage"
+
+test("reading-trail browser script compiles", () => {
+  assert.doesNotThrow(() => new Function(readingTrailScript))
+})
+
+test("reading-trail browser script follows the Quartz render lifecycle", () => {
+  assert.match(readingTrailScript, /sessionStorage\.getItem\(READING_TRAIL_KEY\)/)
+  assert.match(readingTrailScript, /document\.addEventListener\("nav", initializeReadingTrail\)/)
+  assert.match(readingTrailScript, /document\.addEventListener\("render", initializeReadingTrail\)/)
+  assert.match(readingTrailScript, /window\.addCleanup\(cleanupReadingTrail\)/)
+  assert.match(readingTrailScript, /entry\.path !== current\.path/)
+})
+
+test("reading-trail labels use the central locale catalog", () => {
+  assert.equal(enUs.components.readingTrail.trigger({ count: 1 }), "Reading trail, 1 previous note")
+  assert.equal(
+    enUs.components.readingTrail.trigger({ count: 2 }),
+    "Reading trail, 2 previous notes",
+  )
+  assert.equal(zhCn.components.readingTrail.title, "阅读足迹")
+  assert.equal(zhTw.components.readingTrail.clear, "清空閱讀足跡")
+})
+
+describe("reading-trail storage", () => {
+  test("keeps only safe unique entries ordered by their newest visit", () => {
+    const stored = JSON.stringify([
+      { path: "/older", title: " Older ", visitedAt: 10 },
+      { path: "javascript:alert(1)", title: "Unsafe", visitedAt: 50 },
+      { path: "//evil.example", title: "Protocol relative", visitedAt: 50 },
+      { path: "/line\nfeed", title: "Control", visitedAt: 50 },
+      { path: "/newer", title: "Newer", visitedAt: 30 },
+      { path: "/older", title: "Latest older", visitedAt: 20 },
+      { path: "/missing-title", title: "", visitedAt: 60 },
+    ])
+
+    assert.deepEqual(parseReadingTrailEntries(stored), [
+      { path: "/newer", title: "Newer", visitedAt: 30 },
+      { path: "/older", title: "Latest older", visitedAt: 20 },
+    ])
+  })
+
+  test("returns an empty list for malformed JSON", () => {
+    assert.deepEqual(parseReadingTrailEntries("[{"), [])
+  })
+
+  test("moves a revisited note to the front without a duplicate", () => {
+    const entries: readonly ReadingTrailEntry[] = [
+      { path: "/second", title: "Second", visitedAt: 20 },
+      { path: "/first", title: "First", visitedAt: 10 },
+    ]
+    const current = { path: "/first", title: "First again", visitedAt: 30 }
+
+    assert.deepEqual(recordReadingTrailEntry(entries, current), [current, entries[0]])
+  })
+
+  test("bounds the trail to the current note and seven prior notes", () => {
+    const entries: readonly ReadingTrailEntry[] = Array.from(
+      { length: READING_TRAIL_LIMIT },
+      (_, index) => ({ path: `/note-${index}`, title: `Note ${index}`, visitedAt: index }),
+    )
+    const current = { path: "/current", title: "Current", visitedAt: 100 }
+    const updated = recordReadingTrailEntry(entries, current)
+
+    assert.equal(updated.length, READING_TRAIL_LIMIT)
+    assert.deepEqual(updated[0], current)
+    assert.equal(
+      updated.some((entry) => entry.path === "/note-7"),
+      false,
+    )
+  })
+})

--- a/quartz/components/scripts/readingTrail.ts
+++ b/quartz/components/scripts/readingTrail.ts
@@ -1,0 +1,263 @@
+import {
+  READING_TRAIL_LIMIT,
+  parseReadingTrailEntries,
+  parseReadingTrailEntry,
+  recordReadingTrailEntry,
+} from "./readingTrailStorage"
+
+export const readingTrailScript = `
+const READING_TRAIL_KEY = "dg3.readingTrail.v1"
+const READING_TRAIL_LIMIT = ${READING_TRAIL_LIMIT}
+const parseReadingTrailEntry = ${parseReadingTrailEntry.toString()}
+const parseReadingTrailEntries = ${parseReadingTrailEntries.toString()}
+const recordReadingTrailEntry = ${recordReadingTrailEntry.toString()}
+let fallbackReadingTrailEntries = []
+
+function readReadingTrailEntries() {
+  try {
+    const entries = parseReadingTrailEntries(sessionStorage.getItem(READING_TRAIL_KEY))
+    fallbackReadingTrailEntries = entries
+    return entries
+  } catch (error) {
+    if (error instanceof DOMException) return fallbackReadingTrailEntries
+    throw error
+  }
+}
+
+function writeReadingTrailEntries(entries) {
+  fallbackReadingTrailEntries = entries
+  try {
+    sessionStorage.setItem(READING_TRAIL_KEY, JSON.stringify(entries))
+    return true
+  } catch (error) {
+    if (error instanceof DOMException) return false
+    throw error
+  }
+}
+
+function createReadingTrailIcon(pathData, className) {
+  const namespace = "http://www.w3.org/2000/svg"
+  const icon = document.createElementNS(namespace, "svg")
+  icon.classList.add(className)
+  icon.setAttribute("viewBox", "0 0 24 24")
+  icon.setAttribute("fill", "none")
+  icon.setAttribute("stroke", "currentColor")
+  icon.setAttribute("aria-hidden", "true")
+  for (const data of pathData) {
+    const path = document.createElementNS(namespace, "path")
+    path.setAttribute("d", data)
+    icon.append(path)
+  }
+  return icon
+}
+
+function getReadingTrailLabels() {
+  const {
+    readingTrailTitle: title,
+    readingTrailTrigger: serializedTriggers,
+    readingTrailClose: close,
+    readingTrailClear: clear,
+    readingTrailEmpty: empty,
+    readingTrailCleared: cleared,
+    readingTrailFailed: failed,
+  } = document.body.dataset
+  if (!title || !serializedTriggers || !close || !clear || !empty || !cleared || !failed) {
+    return undefined
+  }
+
+  let triggers
+  try {
+    triggers = JSON.parse(serializedTriggers)
+  } catch {
+    return undefined
+  }
+  if (
+    !Array.isArray(triggers) ||
+    triggers.length !== READING_TRAIL_LIMIT + 1 ||
+    triggers.some((label) => typeof label !== "string" || label.length === 0)
+  ) {
+    return undefined
+  }
+  return { title, trigger: (count) => triggers[count], close, clear, empty, cleared, failed }
+}
+
+let cleanupCurrentReadingTrail = () => {}
+const cleanupReadingTrail = () => {
+  const cleanup = cleanupCurrentReadingTrail
+  cleanupCurrentReadingTrail = () => {}
+  cleanup()
+}
+
+function initializeReadingTrail() {
+  cleanupReadingTrail()
+  const titleElement = document.querySelector("h1.article-title")
+  const anchor = document.querySelector(".content-meta") ?? titleElement
+  const title = titleElement?.textContent?.trim()
+  const labels = getReadingTrailLabels()
+  if (anchor === null || !title || labels === undefined) return
+
+  const current = parseReadingTrailEntry({
+    path: location.pathname,
+    title,
+    visitedAt: Date.now(),
+  })
+  if (current === undefined) return
+
+  let entries = recordReadingTrailEntry(readReadingTrailEntries(), current)
+  let storageFailed = !writeReadingTrailEntries(entries)
+  const existingRoot =
+    document.querySelector("[data-read-later-root]") ?? document.querySelector(".note-share-only")
+  const root = existingRoot ?? document.createElement("div")
+  const ownsRoot = existingRoot === null
+  root.classList.add("reader-actions")
+  if (ownsRoot) {
+    root.classList.add("reading-trail-only")
+    anchor.insertAdjacentElement("afterend", root)
+  }
+
+  const trigger = document.createElement("button")
+  trigger.type = "button"
+  trigger.className = "reading-trail-trigger"
+  trigger.setAttribute("aria-controls", "reading-trail-panel")
+  trigger.setAttribute("aria-expanded", "false")
+  trigger.append(
+    createReadingTrailIcon(
+      ["M3 12a9 9 0 1 0 3-6.7L3 8", "M3 3v5h5", "M12 7v5l4 2"],
+      "reading-trail-icon",
+    ),
+  )
+  const count = document.createElement("span")
+  count.className = "reading-trail-count"
+  count.setAttribute("aria-hidden", "true")
+  trigger.append(count)
+
+  const panel = document.createElement("section")
+  panel.id = "reading-trail-panel"
+  panel.className = "reading-trail-panel"
+  panel.setAttribute("aria-label", labels.title)
+  panel.hidden = true
+  const header = document.createElement("header")
+  header.className = "reading-trail-header"
+  const heading = document.createElement("h2")
+  heading.textContent = labels.title
+  const headerActions = document.createElement("div")
+  headerActions.className = "reading-trail-header-actions"
+  const clearButton = document.createElement("button")
+  clearButton.type = "button"
+  clearButton.className = "reading-trail-clear"
+  clearButton.title = labels.clear
+  clearButton.setAttribute("aria-label", labels.clear)
+  clearButton.append(
+    createReadingTrailIcon(
+      ["M3 6h18", "M8 6V4h8v2", "m19 6-1 14H6L5 6", "M10 11v5", "M14 11v5"],
+      "reading-trail-action-icon",
+    ),
+  )
+  const closeButton = document.createElement("button")
+  closeButton.type = "button"
+  closeButton.className = "reading-trail-close"
+  closeButton.textContent = "×"
+  closeButton.title = labels.close
+  closeButton.setAttribute("aria-label", labels.close)
+  headerActions.append(clearButton, closeButton)
+  header.append(heading, headerActions)
+  const list = document.createElement("ol")
+  list.className = "reading-trail-list"
+  const status = document.createElement("p")
+  status.className = "reading-trail-status"
+  status.setAttribute("aria-live", "polite")
+  panel.append(header, list, status)
+  root.prepend(trigger)
+  root.append(panel)
+
+  const closePanel = (restoreFocus) => {
+    panel.hidden = true
+    trigger.setAttribute("aria-expanded", "false")
+    if (restoreFocus) trigger.focus()
+  }
+  const previousEntries = () => entries.filter((entry) => entry.path !== current.path)
+  const render = () => {
+    const previous = previousEntries()
+    count.hidden = previous.length === 0
+    count.textContent = String(previous.length)
+    trigger.title = labels.trigger(previous.length)
+    trigger.setAttribute("aria-label", labels.trigger(previous.length))
+    clearButton.disabled = previous.length === 0
+    list.replaceChildren()
+    if (previous.length === 0) {
+      const empty = document.createElement("li")
+      empty.className = "reading-trail-empty"
+      empty.textContent = labels.empty
+      list.append(empty)
+      return
+    }
+
+    for (const entry of previous) {
+      const item = document.createElement("li")
+      const link = document.createElement("a")
+      link.className = "reading-trail-link internal"
+      link.href = entry.path
+      link.dataset.noPopover = ""
+      const entryTitle = document.createElement("span")
+      entryTitle.className = "reading-trail-entry-title"
+      entryTitle.textContent = entry.title
+      const entryPath = document.createElement("span")
+      entryPath.className = "reading-trail-entry-path"
+      entryPath.textContent = entry.path
+      link.append(entryTitle, entryPath)
+      link.addEventListener("click", () => closePanel(false))
+      item.append(link)
+      list.append(item)
+    }
+  }
+
+  trigger.addEventListener("click", () => {
+    panel.hidden = !panel.hidden
+    trigger.setAttribute("aria-expanded", String(!panel.hidden))
+    if (!panel.hidden) {
+      const readLaterPanel = root.querySelector(".read-later-panel")
+      const readLaterTrigger = root.querySelector(".read-later-trigger")
+      if (readLaterPanel instanceof HTMLElement) readLaterPanel.hidden = true
+      readLaterTrigger?.setAttribute("aria-expanded", "false")
+      if (storageFailed) status.textContent = labels.failed
+      const firstLink = list.querySelector("a")
+      if (firstLink instanceof HTMLElement) firstLink.focus()
+      else closeButton.focus()
+    }
+  })
+  closeButton.addEventListener("click", () => closePanel(true))
+  clearButton.addEventListener("click", () => {
+    entries = []
+    storageFailed = !writeReadingTrailEntries(entries)
+    status.textContent = storageFailed ? labels.failed : labels.cleared
+    render()
+    closeButton.focus()
+  })
+  const dismissOutside = (event) => {
+    if (
+      event.target instanceof Node &&
+      !panel.contains(event.target) &&
+      !trigger.contains(event.target)
+    ) {
+      closePanel(false)
+    }
+  }
+  const dismissWithKeyboard = (event) => {
+    if (event.key === "Escape" && !panel.hidden) closePanel(true)
+  }
+  document.addEventListener("pointerdown", dismissOutside)
+  document.addEventListener("keydown", dismissWithKeyboard)
+  cleanupCurrentReadingTrail = () => {
+    document.removeEventListener("pointerdown", dismissOutside)
+    document.removeEventListener("keydown", dismissWithKeyboard)
+    trigger.remove()
+    panel.remove()
+    if (ownsRoot) root.remove()
+  }
+  window.addCleanup(cleanupReadingTrail)
+  render()
+}
+
+document.addEventListener("nav", initializeReadingTrail)
+document.addEventListener("render", initializeReadingTrail)
+`

--- a/quartz/components/scripts/readingTrailStorage.ts
+++ b/quartz/components/scripts/readingTrailStorage.ts
@@ -1,0 +1,78 @@
+export const READING_TRAIL_LIMIT = 8
+
+export type ReadingTrailEntry = Readonly<{
+  path: string
+  title: string
+  visitedAt: number
+}>
+
+export function parseReadingTrailEntry(candidate: unknown): ReadingTrailEntry | undefined {
+  if (typeof candidate !== "object" || candidate === null) return undefined
+
+  const path: unknown = Reflect.get(candidate, "path")
+  const title: unknown = Reflect.get(candidate, "title")
+  const visitedAt: unknown = Reflect.get(candidate, "visitedAt")
+  if (
+    typeof path !== "string" ||
+    path.length > 2048 ||
+    !path.startsWith("/") ||
+    path.startsWith("//") ||
+    path.includes("\\") ||
+    /[\u0000-\u0020\u007f]/u.test(path) ||
+    typeof title !== "string" ||
+    typeof visitedAt !== "number" ||
+    !Number.isSafeInteger(visitedAt) ||
+    visitedAt < 0
+  ) {
+    return undefined
+  }
+
+  let resolvedPath: URL
+  try {
+    resolvedPath = new URL(path, "https://reading-trail.invalid/")
+  } catch {
+    return undefined
+  }
+  if (resolvedPath.origin !== "https://reading-trail.invalid") return undefined
+
+  const normalizedTitle = title.trim().slice(0, 200)
+  if (normalizedTitle.length === 0) return undefined
+  return { path, title: normalizedTitle, visitedAt }
+}
+
+export function parseReadingTrailEntries(raw: string | null): readonly ReadingTrailEntry[] {
+  if (raw === null) return []
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch (error) {
+    if (error instanceof SyntaxError) return []
+    throw error
+  }
+  if (!Array.isArray(parsed)) return []
+
+  const newestByPath = new Map<string, ReadingTrailEntry>()
+  for (const candidate of parsed as readonly unknown[]) {
+    const entry = parseReadingTrailEntry(candidate)
+    if (entry === undefined) continue
+    const existing = newestByPath.get(entry.path)
+    if (existing === undefined || entry.visitedAt > existing.visitedAt) {
+      newestByPath.set(entry.path, entry)
+    }
+  }
+
+  return [...newestByPath.values()]
+    .sort((first, second) => second.visitedAt - first.visitedAt)
+    .slice(0, READING_TRAIL_LIMIT)
+}
+
+export function recordReadingTrailEntry(
+  entries: readonly ReadingTrailEntry[],
+  current: ReadingTrailEntry,
+): readonly ReadingTrailEntry[] {
+  return [current, ...entries.filter((entry) => entry.path !== current.path)].slice(
+    0,
+    READING_TRAIL_LIMIT,
+  )
+}

--- a/quartz/components/styles/readingTrail.scss
+++ b/quartz/components/styles/readingTrail.scss
@@ -1,0 +1,237 @@
+.reading-trail-only {
+  position: relative;
+  z-index: 3;
+  display: flex;
+  width: fit-content;
+  margin-block: -0.5rem 1rem;
+  margin-inline: auto 0;
+  justify-content: flex-end;
+}
+
+.reading-trail-trigger,
+.reading-trail-close,
+.reading-trail-clear {
+  appearance: none;
+  box-sizing: border-box;
+  border: 1px solid color-mix(in srgb, var(--gray) 54%, transparent);
+  border-radius: 6px;
+  background-color: var(--light);
+  color: var(--dark);
+  font: inherit;
+  cursor: pointer;
+  touch-action: manipulation;
+  transition:
+    background-color 0.15s ease-out,
+    color 0.15s ease-out,
+    transform 0.15s ease-out;
+
+  &:hover:not(:disabled) {
+    border-color: var(--secondary);
+    background-color: var(--lightgray);
+    color: var(--secondary);
+  }
+
+  &:active:not(:disabled) {
+    transform: scale(0.96);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--secondary);
+    outline-offset: 2px;
+  }
+
+  &:disabled {
+    cursor: default;
+    opacity: 0.45;
+  }
+}
+
+.reading-trail-trigger {
+  position: relative;
+  display: grid;
+  width: 2.5rem;
+  height: 2.5rem;
+  flex: 0 0 2.5rem;
+  padding: 0;
+  place-items: center;
+}
+
+.reading-trail-icon,
+.reading-trail-action-icon {
+  width: 1.125rem;
+  height: 1.125rem;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 2;
+}
+
+.reading-trail-count {
+  position: absolute;
+  inset-block-start: -0.375rem;
+  inset-inline-end: -0.375rem;
+  display: grid;
+  min-width: 1rem;
+  height: 1rem;
+  padding: 0 0.2rem;
+  place-items: center;
+  border: 1px solid var(--light);
+  border-radius: 999px;
+  background-color: var(--secondary);
+  color: var(--light);
+  font-family: var(--codeFont);
+  font-size: 0.625rem;
+  line-height: 1;
+
+  &[hidden] {
+    display: none;
+  }
+}
+
+.reading-trail-panel {
+  position: absolute;
+  inset-block-start: calc(100% + 0.5rem);
+  inset-inline-end: 0;
+  box-sizing: border-box;
+  width: min(20rem, calc(100vw - 2rem));
+  padding: 0.75rem;
+  border: 1px solid color-mix(in srgb, var(--gray) 54%, transparent);
+  border-radius: 6px;
+  background-color: var(--light);
+  color: var(--darkgray);
+
+  &[hidden] {
+    display: none;
+  }
+}
+
+.reading-trail-header,
+.reading-trail-header-actions {
+  display: flex;
+  align-items: center;
+}
+
+.reading-trail-header {
+  min-height: 2rem;
+  justify-content: space-between;
+  gap: 0.75rem;
+
+  h2 {
+    margin: 0;
+    font-size: 1rem;
+    letter-spacing: 0;
+    line-height: 1.25;
+  }
+}
+
+.reading-trail-header-actions {
+  gap: 0.375rem;
+}
+
+.reading-trail-close,
+.reading-trail-clear {
+  display: grid;
+  width: 2rem;
+  height: 2rem;
+  flex: 0 0 2rem;
+  padding: 0;
+  place-items: center;
+  line-height: 1;
+}
+
+.reading-trail-close {
+  font-family: var(--codeFont);
+  font-size: 1.125rem;
+}
+
+.reading-trail-list {
+  max-height: 15rem;
+  margin: 0.75rem 0 0;
+  padding: 0;
+  overflow-y: auto;
+  list-style: none;
+
+  > li + li {
+    border-top: 1px solid var(--lightgray);
+  }
+}
+
+.reading-trail-link {
+  display: grid;
+  min-width: 0;
+  padding: 0.625rem 0.25rem;
+  gap: 0.125rem;
+  text-decoration: none;
+}
+
+.reading-trail-entry-title,
+.reading-trail-entry-path {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.reading-trail-entry-title {
+  display: -webkit-box;
+  overflow: hidden;
+  color: var(--dark);
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  line-height: 1.35;
+}
+
+.reading-trail-entry-path {
+  overflow: hidden;
+  color: var(--gray);
+  font-family: var(--codeFont);
+  font-size: 0.75rem;
+  line-height: 1.35;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.reading-trail-link:hover .reading-trail-entry-title,
+.reading-trail-link:focus-visible .reading-trail-entry-title {
+  color: var(--secondary);
+}
+
+.reading-trail-link:focus-visible {
+  border-radius: 4px;
+  outline: 2px solid var(--secondary);
+  outline-offset: -2px;
+}
+
+.reading-trail-empty {
+  padding: 0.75rem 0.25rem;
+  color: var(--gray);
+  line-height: 1.5;
+}
+
+.reading-trail-status {
+  margin: 0.5rem 0 0;
+  color: var(--gray);
+  font-size: 0.875rem;
+  line-height: 1.4;
+
+  &:empty {
+    display: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .reading-trail-trigger,
+  .reading-trail-close,
+  .reading-trail-clear {
+    transition: none;
+
+    &:active {
+      transform: none;
+    }
+  }
+}
+
+@media print {
+  .reading-trail-trigger,
+  .reading-trail-panel,
+  .reading-trail-only {
+    display: none;
+  }
+}

--- a/quartz/i18n/locales/definition.ts
+++ b/quartz/i18n/locales/definition.ts
@@ -113,6 +113,15 @@ export interface Translation {
       value: string
       failed: string
     }
+    readingTrail?: {
+      title: string
+      trigger: (variables: { count: number }) => string
+      close: string
+      clear: string
+      empty: string
+      cleared: string
+      failed: string
+    }
     explorer: {
       title: string
     }

--- a/quartz/i18n/locales/en-US.ts
+++ b/quartz/i18n/locales/en-US.ts
@@ -110,6 +110,16 @@ export default {
       value: "Article text at {percent}%",
       failed: "Applied, but the browser could not save this preference",
     },
+    readingTrail: {
+      title: "Reading trail",
+      trigger: ({ count }) =>
+        count === 1 ? "Reading trail, 1 previous note" : `Reading trail, ${count} previous notes`,
+      close: "Close reading trail",
+      clear: "Clear reading trail",
+      empty: "No previous notes in this tab yet",
+      cleared: "Reading trail cleared",
+      failed: "The browser could not keep this reading trail",
+    },
     explorer: {
       title: "Explorer",
     },

--- a/quartz/i18n/locales/zh-CN.ts
+++ b/quartz/i18n/locales/zh-CN.ts
@@ -110,6 +110,15 @@ export default {
       value: "正文字号 {percent}%",
       failed: "已应用，但浏览器未能保存偏好",
     },
+    readingTrail: {
+      title: "阅读足迹",
+      trigger: ({ count }) => `阅读足迹，前面有 ${count} 篇笔记`,
+      close: "关闭阅读足迹",
+      clear: "清空阅读足迹",
+      empty: "这个标签页还没有之前读过的笔记",
+      cleared: "阅读足迹已清空",
+      failed: "浏览器未能保留阅读足迹",
+    },
     explorer: {
       title: "探索",
     },

--- a/quartz/i18n/locales/zh-TW.ts
+++ b/quartz/i18n/locales/zh-TW.ts
@@ -107,6 +107,15 @@ export default {
       value: "正文字號 {percent}%",
       failed: "已套用，但瀏覽器未能儲存偏好",
     },
+    readingTrail: {
+      title: "閱讀足跡",
+      trigger: ({ count }) => `閱讀足跡，前面有 ${count} 篇筆記`,
+      close: "關閉閱讀足跡",
+      clear: "清空閱讀足跡",
+      empty: "這個分頁還沒有之前讀過的筆記",
+      cleared: "閱讀足跡已清空",
+      failed: "瀏覽器未能保留閱讀足跡",
+    },
     explorer: {
       title: "探索",
     },

--- a/quartz/plugins/emitters/componentResources.test.ts
+++ b/quartz/plugins/emitters/componentResources.test.ts
@@ -257,4 +257,22 @@ describe("componentResources", () => {
       assert.ok(styleIndex < spaBranchIndex)
     })
   })
+
+  test("includes the reading trail when SPA navigation is disabled", () => {
+    const emitterPath = new URL("./componentResources.ts", import.meta.url)
+    const source = readFile(emitterPath, "utf8")
+
+    return source.then((contents) => {
+      const scriptIndex = contents.indexOf(
+        "componentResources.afterDOMLoaded.push(readingTrailScript)",
+      )
+      const styleIndex = contents.indexOf("componentResources.css.push(readingTrailStyle)")
+      const spaBranchIndex = contents.indexOf("if (cfg.enableSPA)")
+
+      assert.notEqual(scriptIndex, -1)
+      assert.notEqual(styleIndex, -1)
+      assert.ok(scriptIndex < spaBranchIndex)
+      assert.ok(styleIndex < spaBranchIndex)
+    })
+  })
 })

--- a/quartz/plugins/emitters/componentResources.ts
+++ b/quartz/plugins/emitters/componentResources.ts
@@ -39,6 +39,8 @@ import {
   readingComfortScript,
 } from "../../components/scripts/readingComfort"
 import readingComfortStyle from "../../components/styles/readingComfort.scss"
+import { readingTrailScript } from "../../components/scripts/readingTrail"
+import readingTrailStyle from "../../components/styles/readingTrail.scss"
 import { BuildCtx } from "../../util/ctx"
 import { QuartzComponent } from "../../components/types"
 import { normalizeResource } from "../../util/resources"
@@ -142,6 +144,8 @@ function addGlobalPageResources(ctx: BuildCtx, componentResources: ComponentReso
   componentResources.beforeDOMLoaded.push(readingComfortBootstrapScript)
   componentResources.afterDOMLoaded.push(readingComfortScript)
   componentResources.css.push(readingComfortStyle)
+  componentResources.afterDOMLoaded.push(readingTrailScript)
+  componentResources.css.push(readingTrailStyle)
 
   // popovers
   if (cfg.enablePopovers) {


### PR DESCRIPTION
Built a localized Reading Trail that remembers the notes visited earlier in the current tab and makes them one click away from the existing reader action row. I think it is worth merging because wandering through backlinks and Random Wander is one of the garden's best interactions, and this gives readers a quiet, reversible path through that exploration without accounts, long-term tracking, or another network request.

## What changed

- keep up to eight safe, unique note paths in `sessionStorage`, newest first
- show a compact count badge and anchored trail panel with title/path context
- move revisited notes to the front, exclude the current note, and support clear/empty/failure states
- handle Quartz SPA `nav`, in-place `render`, full reload, cleanup, and `ReadLater` panel mutual exclusion
- localize English, Simplified Chinese, and Traditional Chinese labels
- support keyboard focus restoration, Escape, outside dismissal, dark/light, reduced motion, print, long lists, and extreme CJK/path lengths

## Validation

- focused tests: 28/28 passed
- `tsc --noEmit`: passed
- scoped Prettier and `git diff --check`: passed
- production Quartz build: passed, 314 inputs / 1911 outputs
- real Chromium QA: SPA order/revisit/uniqueness, reload, clear, Escape/focus, `ReadLater` exclusion, 1280px desktop, 320px mobile, dark/light, reduced motion, long-list scrolling, and extreme text clamping all passed with no page errors
- full suite: 230/231; the sole failure is the existing ThemeSwitcher test importing undeclared `jsdom`, in unchanged code
- remote checks: all four Netlify checks failed together after about 10 minutes; public deploy `6a8c8e6facc50100081c10cd` ended in `error` with no error message and GitHub exposed zero annotations, so no deployment configuration or credentials were changed

## Impact

- 13 focused design, runtime, storage, style, locale, resource-registration, and test files
- no dependency, lockfile, content, config, CI, infrastructure, deployment, analytics, cookie, permission, secret, or external-request changes
- session data is bounded to eight path/title/timestamp entries and disappears with the tab session
- GitHub Issues are disabled for this repository, so there is no linked issue

## Rollback

Revert commit `c1cdc31a08cb5350cf7570a2a12e3062cba9cb3e`. The feature is isolated; removing its script/style registration, locale fields, and storage module restores the prior reader action row. Existing browser session data is inert without the script.
