### PR TITLE
feat(reader): add wide content scroll cues

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -211,6 +211,13 @@ Layout rules:
 - **Accessibility**: The button and polite live region use page-localized names and outcomes. The icon is decorative, the control remains keyboard-operable, and whole-note links omit heading fragments so section sharing stays owned by heading permalinks.
 - **Motion**: The beui `action-swap` blur/scale mechanism is adapted to the existing 150ms micro token, using a 3px blur and 75% scale only during the icon crossfade. Reduced-motion mode removes blur, scale, and press transforms while preserving the state change.
 
+### WideContentScroll
+
+- **Structure**: Wide tables and code blocks gain quiet inset edge cues only while content remains clipped on that side. Mermaid blocks keep their dedicated controls and are excluded.
+- **Behavior**: Resize, horizontal scroll, initial load, SPA navigation, and in-place render events recalculate both edges without duplicating listeners or leaving stale attributes.
+- **Accessibility**: Only genuinely overflowing containers enter the tab order. Each receives a localized accessible name and supports native keyboard scrolling; the existing 2px focus ring identifies the active region.
+- **Motion**: Edge cues use the 150ms micro transition and existing Quartz tokens. Reduced-motion removes the transition, and print removes both cues and focus decoration.
+
 ## 6. Motion & Interaction
 
 Motion is quiet utility feedback, not brand theater.

--- a/quartz/components/renderPage.tsx
+++ b/quartz/components/renderPage.tsx
@@ -373,6 +373,9 @@ export function renderPage(
   const randomWander = i18n(pageLocale).components.randomWander ?? fallbackRandomWander
   const fallbackNoteShare = TRANSLATIONS[defaultTranslation].components.noteShare
   const noteShare = i18n(pageLocale).components.noteShare ?? fallbackNoteShare
+  const fallbackWideContentScroll = TRANSLATIONS[defaultTranslation].components.wideContentScroll
+  const wideContentScroll =
+    i18n(pageLocale).components.wideContentScroll ?? fallbackWideContentScroll
   // During local dev (--serve), the dev server serves from root without the
   // baseUrl subpath, so basePath must be empty to avoid broken links.
   const basePath =
@@ -410,6 +413,8 @@ export function renderPage(
         data-note-share-shared={noteShare.shared}
         data-note-share-copied={noteShare.copied}
         data-note-share-failed={noteShare.failed}
+        data-wide-content-table={wideContentScroll.table}
+        data-wide-content-code={wideContentScroll.code}
       >
         {frame.css && <style dangerouslySetInnerHTML={{ __html: frame.css }} />}
         <div id="quartz-root" class="page" data-frame={frame.name}>

--- a/quartz/components/scripts/wideContentScroll.test.ts
+++ b/quartz/components/scripts/wideContentScroll.test.ts
@@ -1,0 +1,92 @@
+import assert from "node:assert"
+import test, { describe } from "node:test"
+import enUs from "../../i18n/locales/en-US"
+import zhCn from "../../i18n/locales/zh-CN"
+import zhTw from "../../i18n/locales/zh-TW"
+import {
+  wideContentLabels,
+  wideContentScrollScript,
+  wideContentScrollState,
+} from "./wideContentScroll"
+
+describe("wide-content scroll state", () => {
+  test("keeps a fitting container inactive", () => {
+    assert.deepEqual(wideContentScrollState(0, 320, 320), {
+      overflowing: false,
+      before: false,
+      after: false,
+    })
+  })
+
+  test("tracks the start, middle, and end of left-to-right content", () => {
+    assert.deepEqual(wideContentScrollState(0, 320, 640), {
+      overflowing: true,
+      before: false,
+      after: true,
+    })
+    assert.deepEqual(wideContentScrollState(160, 320, 640), {
+      overflowing: true,
+      before: true,
+      after: true,
+    })
+    assert.deepEqual(wideContentScrollState(320, 320, 640), {
+      overflowing: true,
+      before: true,
+      after: false,
+    })
+  })
+
+  test("normalizes negative right-to-left scroll offsets", () => {
+    assert.deepEqual(wideContentScrollState(-320, 320, 640, "rtl"), {
+      overflowing: true,
+      before: true,
+      after: false,
+    })
+  })
+})
+
+describe("wide-content labels", () => {
+  test("reads complete labels rendered by Quartz i18n", () => {
+    const labels = wideContentLabels({
+      wideContentTable: "Scrollable table",
+      wideContentCode: "Scrollable code block",
+    } as DOMStringMap)
+
+    assert.deepEqual(labels, {
+      table: "Scrollable table",
+      code: "Scrollable code block",
+    })
+  })
+
+  test("does not initialize with incomplete labels", () => {
+    assert.equal(
+      wideContentLabels({ wideContentTable: "Scrollable table" } as DOMStringMap),
+      undefined,
+    )
+  })
+})
+
+test("wide-content browser script compiles", () => {
+  assert.doesNotThrow(() => new Function(wideContentScrollScript))
+})
+
+test("wide-content browser script handles Quartz lifecycle cleanup", () => {
+  assert.doesNotMatch(wideContentScrollScript, /\ninitializeWideContentScroll\(\)\n/)
+  assert.match(
+    wideContentScrollScript,
+    /document\.addEventListener\("nav", initializeWideContentScroll\)/,
+  )
+  assert.match(
+    wideContentScrollScript,
+    /document\.addEventListener\("render", initializeWideContentScroll\)/,
+  )
+  assert.match(wideContentScrollScript, /window\.addCleanup\(cleanupWideContentScroll\)/)
+  assert.match(wideContentScrollScript, /resizeObserver\?\.disconnect\(\)/)
+  assert.match(wideContentScrollScript, /pre > code:not\(\.mermaid\)/)
+})
+
+test("wide-content labels use the central locale catalog", () => {
+  assert.equal(enUs.components.wideContentScroll.table, "Scrollable table")
+  assert.equal(zhCn.components.wideContentScroll.code, "可横向滚动的代码块")
+  assert.equal(zhTw.components.wideContentScroll.table, "可橫向捲動的表格")
+})

--- a/quartz/components/scripts/wideContentScroll.ts
+++ b/quartz/components/scripts/wideContentScroll.ts
@@ -1,0 +1,128 @@
+export type WideContentScrollState = {
+  readonly overflowing: boolean
+  readonly before: boolean
+  readonly after: boolean
+}
+
+export function wideContentScrollState(
+  scrollLeft: number,
+  clientWidth: number,
+  scrollWidth: number,
+  direction: "ltr" | "rtl" = "ltr",
+): WideContentScrollState {
+  const maximum = Math.max(0, scrollWidth - clientWidth)
+  const travelled = Math.min(
+    maximum,
+    Math.max(0, direction === "rtl" ? Math.abs(scrollLeft) : scrollLeft),
+  )
+  const overflowing = maximum > 1
+
+  return {
+    overflowing,
+    before: overflowing && travelled > 1,
+    after: overflowing && travelled < maximum - 1,
+  }
+}
+
+export type WideContentLabels = {
+  readonly table: string
+  readonly code: string
+}
+
+export function wideContentLabels(dataset: DOMStringMap): WideContentLabels | undefined {
+  const { wideContentTable: table, wideContentCode: code } = dataset
+  if (!table || !code) return undefined
+  return { table, code }
+}
+
+export const wideContentScrollScript = `
+const wideContentScrollState = ${wideContentScrollState.toString()}
+const wideContentLabels = ${wideContentLabels.toString()}
+
+let cleanupCurrentWideContentScroll = () => {}
+const cleanupWideContentScroll = () => {
+  const cleanup = cleanupCurrentWideContentScroll
+  cleanupCurrentWideContentScroll = () => {}
+  cleanup()
+}
+
+function initializeWideContentScroll() {
+  cleanupWideContentScroll()
+  const labels = wideContentLabels(document.body.dataset)
+  if (labels === undefined) return
+
+  const targets = Array.from(
+    document.querySelectorAll(".table-container, article pre > code:not(.mermaid)"),
+  ).filter((target) => target instanceof HTMLElement)
+  if (targets.length === 0) return
+
+  const cleanups = []
+  const updates = []
+  const resizeObserver =
+    typeof ResizeObserver === "undefined" ? undefined : new ResizeObserver(() => updateAll())
+
+  const updateAll = () => {
+    for (const update of updates) update()
+  }
+
+  for (const target of targets) {
+    const originalTabIndex = target.getAttribute("tabindex")
+    const originalLabel = target.getAttribute("aria-label")
+    const hadClass = target.classList.contains("wide-content-scroll")
+    const label = target.matches(".table-container")
+      ? labels.table
+      : labels.code
+
+    const restoreAccessibility = () => {
+      if (originalTabIndex === null) target.removeAttribute("tabindex")
+      else target.setAttribute("tabindex", originalTabIndex)
+      if (originalLabel === null) target.removeAttribute("aria-label")
+      else target.setAttribute("aria-label", originalLabel)
+    }
+    const update = () => {
+      const direction = getComputedStyle(target).direction === "rtl" ? "rtl" : "ltr"
+      const state = wideContentScrollState(
+        target.scrollLeft,
+        target.clientWidth,
+        target.scrollWidth,
+        direction,
+      )
+
+      target.classList.toggle("wide-content-scroll", state.overflowing || hadClass)
+      target.toggleAttribute("data-scroll-before", state.before)
+      target.toggleAttribute("data-scroll-after", state.after)
+      if (state.overflowing) {
+        if (originalTabIndex === null) target.tabIndex = 0
+        if (originalLabel === null) target.setAttribute("aria-label", label)
+      } else {
+        restoreAccessibility()
+      }
+    }
+
+    updates.push(update)
+    target.addEventListener("scroll", update, { passive: true })
+    resizeObserver?.observe(target)
+    if (target.firstElementChild) resizeObserver?.observe(target.firstElementChild)
+    update()
+
+    cleanups.push(() => {
+      target.removeEventListener("scroll", update)
+      target.removeAttribute("data-scroll-before")
+      target.removeAttribute("data-scroll-after")
+      if (!hadClass) target.classList.remove("wide-content-scroll")
+      restoreAccessibility()
+    })
+  }
+
+  window.addEventListener("resize", updateAll)
+  cleanupCurrentWideContentScroll = () => {
+    resizeObserver?.disconnect()
+    window.removeEventListener("resize", updateAll)
+    for (const cleanup of cleanups) cleanup()
+  }
+  window.addCleanup(cleanupWideContentScroll)
+}
+
+document.addEventListener("nav", initializeWideContentScroll)
+document.addEventListener("render", initializeWideContentScroll)
+`

--- a/quartz/components/styles/wideContentScroll.scss
+++ b/quartz/components/styles/wideContentScroll.scss
@@ -1,0 +1,48 @@
+.wide-content-scroll {
+  --wide-content-before-shadow: inset 0 0 transparent;
+  --wide-content-after-shadow: inset 0 0 transparent;
+
+  box-shadow: var(--wide-content-before-shadow), var(--wide-content-after-shadow);
+  scroll-padding-inline: 0.75rem;
+  transition: box-shadow 0.15s ease-out;
+
+  &[data-scroll-before] {
+    --wide-content-before-shadow: inset 12px 0 10px -10px
+      color-mix(in srgb, var(--darkgray) 42%, transparent);
+  }
+
+  &[data-scroll-after] {
+    --wide-content-after-shadow: inset -12px 0 10px -10px
+      color-mix(in srgb, var(--darkgray) 42%, transparent);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--secondary);
+    outline-offset: 2px;
+  }
+}
+
+html[dir="rtl"] .wide-content-scroll {
+  &[data-scroll-before] {
+    --wide-content-before-shadow: inset -12px 0 10px -10px
+      color-mix(in srgb, var(--darkgray) 42%, transparent);
+  }
+
+  &[data-scroll-after] {
+    --wide-content-after-shadow: inset 12px 0 10px -10px
+      color-mix(in srgb, var(--darkgray) 42%, transparent);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .wide-content-scroll {
+    transition: none;
+  }
+}
+
+@media print {
+  .wide-content-scroll {
+    box-shadow: none;
+    outline: none;
+  }
+}

--- a/quartz/i18n/locales/definition.ts
+++ b/quartz/i18n/locales/definition.ts
@@ -83,6 +83,10 @@ export interface Translation {
       copied: string
       failed: string
     }
+    wideContentScroll?: {
+      table: string
+      code: string
+    }
     explorer: {
       title: string
     }

--- a/quartz/i18n/locales/en-US.ts
+++ b/quartz/i18n/locales/en-US.ts
@@ -80,6 +80,10 @@ export default {
       copied: "Note link copied",
       failed: "The browser could not share this note",
     },
+    wideContentScroll: {
+      table: "Scrollable table",
+      code: "Scrollable code block",
+    },
     explorer: {
       title: "Explorer",
     },

--- a/quartz/i18n/locales/zh-CN.ts
+++ b/quartz/i18n/locales/zh-CN.ts
@@ -80,6 +80,10 @@ export default {
       copied: "笔记链接已复制",
       failed: "浏览器未能分享这篇笔记",
     },
+    wideContentScroll: {
+      table: "可横向滚动的表格",
+      code: "可横向滚动的代码块",
+    },
     explorer: {
       title: "探索",
     },

--- a/quartz/i18n/locales/zh-TW.ts
+++ b/quartz/i18n/locales/zh-TW.ts
@@ -77,6 +77,10 @@ export default {
       copied: "筆記連結已複製",
       failed: "瀏覽器未能分享這篇筆記",
     },
+    wideContentScroll: {
+      table: "可橫向捲動的表格",
+      code: "可橫向捲動的程式碼區塊",
+    },
     explorer: {
       title: "探索",
     },

--- a/quartz/plugins/emitters/componentResources.test.ts
+++ b/quartz/plugins/emitters/componentResources.test.ts
@@ -143,4 +143,22 @@ describe("componentResources", () => {
       assert.ok(noteShareStyleIndex < spaBranchIndex)
     })
   })
+
+  test("includes wide-content scroll cues when SPA navigation is disabled", () => {
+    const emitterPath = new URL("./componentResources.ts", import.meta.url)
+    const source = readFile(emitterPath, "utf8")
+
+    return source.then((contents) => {
+      const scriptIndex = contents.indexOf(
+        "componentResources.afterDOMLoaded.push(wideContentScrollScript)",
+      )
+      const styleIndex = contents.indexOf("componentResources.css.push(wideContentScrollStyle)")
+      const spaBranchIndex = contents.indexOf("if (cfg.enableSPA)")
+
+      assert.notEqual(scriptIndex, -1)
+      assert.notEqual(styleIndex, -1)
+      assert.ok(scriptIndex < spaBranchIndex)
+      assert.ok(styleIndex < spaBranchIndex)
+    })
+  })
 })

--- a/quartz/plugins/emitters/componentResources.ts
+++ b/quartz/plugins/emitters/componentResources.ts
@@ -24,6 +24,8 @@ import { randomWanderScript } from "../../components/scripts/randomWander"
 import randomWanderStyle from "../../components/styles/randomWander.scss"
 import { noteShareScript } from "../../components/scripts/noteShare"
 import noteShareStyle from "../../components/styles/noteShare.scss"
+import { wideContentScrollScript } from "../../components/scripts/wideContentScroll"
+import wideContentScrollStyle from "../../components/styles/wideContentScroll.scss"
 import { BuildCtx } from "../../util/ctx"
 import { QuartzComponent } from "../../components/types"
 import { normalizeResource } from "../../util/resources"
@@ -114,6 +116,8 @@ function addGlobalPageResources(ctx: BuildCtx, componentResources: ComponentReso
   componentResources.css.push(randomWanderStyle)
   componentResources.afterDOMLoaded.push(noteShareScript)
   componentResources.css.push(noteShareStyle)
+  componentResources.afterDOMLoaded.push(wideContentScrollScript)
+  componentResources.css.push(wideContentScrollStyle)
 
   // popovers
   if (cfg.enablePopovers) {


### PR DESCRIPTION
This builds quiet horizontal-scroll cues for genuinely wide tables and code blocks: inset edge shadows show which direction still contains clipped content, while keyboard users get a localized, focusable scroll region only when overflow actually exists. It feels worth merging because dense notes become easier to explore on narrow screens without adding a persistent control, changing content, or cluttering layouts that already fit.

## What changed

- Detect overflowing table containers and non-Mermaid code blocks after Quartz render/navigation events.
- Show start/end edge cues that follow the current scroll position and update on resize or content changes.
- Add localized accessible names for English, Simplified Chinese, and Traditional Chinese.
- Preserve existing accessibility attributes and remove the enhancement when content fits.
- Respect reduced-motion and print modes.

## Validation

- `npx tsx --test quartz/components/scripts/wideContentScroll.test.ts quartz/plugins/emitters/componentResources.test.ts quartz/components/renderPage.test.ts` (28/28 passed)
- `npx tsc --noEmit` (passed)
- `npx prettier --check ...` for all changed source/style/test files (passed)
- `npx quartz build` (passed: 1,911 files emitted from 314 inputs)
- `npm test` (230/231 passed; the pre-existing `local-plugins/theme-switcher/test/themeSwitcherScript.test.ts` still cannot resolve undeclared `jsdom`)
- Real Chromium QA at 390x844 and 1280x900 in light/dark and reduced-motion modes: verified cue states at start/middle/end, ArrowRight scrolling and focus ring, no page-level overflow, automatic removal when content fits, and SPA away/back reinitialization.

## Impact

- Reader-only enhancement for overflowing tables and code blocks.
- No dependency, configuration, content, deployment, or data changes.
- Mermaid keeps its existing dedicated interaction and is excluded.

## Rollback

Revert this commit to remove the global script/style registration, rendered labels, and cue assets; no migration or cleanup is required.

## Known issues

- The repository-wide test command remains red on the existing undeclared `jsdom` import described above; all tests touching this change pass.
