### PR TITLE
feat(reader): add local link wander

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -204,6 +204,15 @@ Layout rules:
 - **States**: Hidden until the content index resolves; default, hover, pressed, and focus-visible once a destination is available. Reinitialize idempotently after SPA navigation and in-place renders.
 - **Accessibility**: Use a native internal link so open-in-new-tab and browser navigation remain available. The icon is decorative; the tooltip and accessible name follow the page language.
 - **Motion**: Reuse the existing 150ms color and press feedback. Reduced-motion mode removes the press transform.
+
+### LocalLinkWander
+
+- **Structure**: One 40px native internal-link control in the existing reader action row. Its route icon distinguishes a connected hop from the whole-garden shuffle action.
+- **Destination**: Choose uniformly from visible published internal links authored in the current article, cross-checked against Quartz's existing content index. Exclude the current path, broken links, transclusions, footnotes, hidden links, duplicates, cross-origin URLs, and links that escape the configured base path.
+- **States**: Stay hidden until the content index resolves and omit the control when no safe destination exists; otherwise provide default, hover, pressed, and focus-visible states. Reinitialize idempotently after SPA navigation and in-place renders.
+- **Accessibility**: Preserve native link and open-in-new-tab behavior. The icon is decorative; the tooltip and accessible name follow the page language.
+- **Motion**: Reuse the existing 150ms color and press feedback. Reduced-motion mode removes the press transform, and print hides the control.
+
 ### NoteShare
 
 - **Structure**: One 40px share action beside `ReadLater`; it uses the browser's native share sheet when available and copies the current note URL otherwise. If `ReadLater` is unavailable, the action keeps the same inline-end placement in its own compact action group.

--- a/quartz/components/renderPage.tsx
+++ b/quartz/components/renderPage.tsx
@@ -371,6 +371,8 @@ export function renderPage(
   const resumeReading = i18n(pageLocale).components.resumeReading ?? fallbackResumeReading
   const fallbackRandomWander = TRANSLATIONS[defaultTranslation].components.randomWander
   const randomWander = i18n(pageLocale).components.randomWander ?? fallbackRandomWander
+  const fallbackLocalLinkWander = TRANSLATIONS[defaultTranslation].components.localLinkWander
+  const localLinkWander = i18n(pageLocale).components.localLinkWander ?? fallbackLocalLinkWander
   const fallbackNoteShare = TRANSLATIONS[defaultTranslation].components.noteShare
   const noteShare = i18n(pageLocale).components.noteShare ?? fallbackNoteShare
   const fallbackWideContentScroll = TRANSLATIONS[defaultTranslation].components.wideContentScroll
@@ -409,6 +411,7 @@ export function renderPage(
         data-resume-reading-dismiss={resumeReading.dismiss}
         data-resume-reading-region={resumeReading.region}
         data-random-wander-label={randomWander.title}
+        data-local-link-wander-label={localLinkWander.title}
         data-note-share-title={noteShare.title}
         data-note-share-shared={noteShare.shared}
         data-note-share-copied={noteShare.copied}

--- a/quartz/components/scripts/localLinkWander.test.ts
+++ b/quartz/components/scripts/localLinkWander.test.ts
@@ -1,0 +1,88 @@
+import assert from "node:assert"
+import test, { describe } from "node:test"
+import enUs from "../../i18n/locales/en-US"
+import zhCn from "../../i18n/locales/zh-CN"
+import zhTw from "../../i18n/locales/zh-TW"
+import {
+  isPublishedLocalLinkWanderSlug,
+  localLinkWanderScript,
+  normalizeLocalLinkWanderHref,
+  pickLocalLinkWanderHref,
+} from "./localLinkWander"
+
+describe("local-link wander destinations", () => {
+  const current = "https://garden.example/garden/current?mode=read#section"
+
+  test("normalizes safe links within the configured site path", () => {
+    assert.equal(
+      normalizeLocalLinkWanderHref("./Cards/Delight#idea", current, "/garden"),
+      "/garden/Cards/Delight#idea",
+    )
+    assert.equal(
+      normalizeLocalLinkWanderHref(
+        "https://garden.example/garden/80%25%E6%97%B6%E9%97%B4%E8%BE%93%E5%85%A5?q=1",
+        current,
+        "/garden",
+      ),
+      "/garden/80%25%E6%97%B6%E9%97%B4%E8%BE%93%E5%85%A5?q=1",
+    )
+  })
+
+  test("rejects self-links, cross-origin URLs, and path escapes", () => {
+    for (const href of [
+      "#section-two",
+      "/garden/current#other",
+      "https://evil.example/garden/note",
+      "//evil.example/note",
+      "\\evil.example\\note",
+      "/outside",
+      "/garden/folder/%2foutside",
+      "https://user@garden.example/garden/note",
+      "javascript:alert(1)",
+    ]) {
+      assert.equal(normalizeLocalLinkWanderHref(href, current, "/garden"), undefined)
+    }
+  })
+
+  test("deduplicates destinations and chooses by document order", () => {
+    const hrefs = ["/garden/alpha", "/garden/alpha#section", "/garden/alpha", "/garden/beta"]
+
+    assert.equal(pickLocalLinkWanderHref(hrefs, current, "/garden", 0), "/garden/alpha")
+    assert.equal(pickLocalLinkWanderHref(hrefs, current, "/garden", 0.999), "/garden/beta")
+  })
+
+  test("returns no destination when every link is ineligible", () => {
+    assert.equal(pickLocalLinkWanderHref(["#same", "/outside"], current, "/garden", 0.5), undefined)
+    assert.equal(pickLocalLinkWanderHref(["/garden/next"], current, "/garden", NaN), undefined)
+  })
+
+  test("accepts only own slugs from the published content index", () => {
+    const index = Object.assign(Object.create({ inherited: {} }), { published: {} })
+
+    assert.equal(isPublishedLocalLinkWanderSlug(index, "published"), true)
+    assert.equal(isPublishedLocalLinkWanderSlug(index, "missing"), false)
+    assert.equal(isPublishedLocalLinkWanderSlug(index, "inherited"), false)
+    assert.equal(isPublishedLocalLinkWanderSlug(index, undefined), false)
+  })
+})
+
+test("local-link wander browser script compiles and follows the Quartz lifecycle", () => {
+  assert.doesNotThrow(() => new Function(localLinkWanderScript))
+  assert.match(
+    localLinkWanderScript,
+    /document\.addEventListener\("nav", initializeLocalLinkWander\)/,
+  )
+  assert.match(
+    localLinkWanderScript,
+    /document\.addEventListener\("render", initializeLocalLinkWander\)/,
+  )
+  assert.match(localLinkWanderScript, /window\.addCleanup\(cleanupLocalLinkWander\)/)
+  assert.match(localLinkWanderScript, /\.transclude, \[data-footnote-ref\]/)
+  assert.match(localLinkWanderScript, /fetchData\.then/)
+})
+
+test("local-link wander labels use the central locale catalog", () => {
+  assert.equal(enUs.components.localLinkWander.title, "Follow a link from this note")
+  assert.equal(zhCn.components.localLinkWander.title, "顺着当前笔记漫游")
+  assert.equal(zhTw.components.localLinkWander.title, "順著目前筆記漫遊")
+})

--- a/quartz/components/scripts/localLinkWander.ts
+++ b/quartz/components/scripts/localLinkWander.ts
@@ -1,0 +1,188 @@
+type LocalLinkWanderIndex = Readonly<Record<string, unknown>>
+
+export function isPublishedLocalLinkWanderSlug(
+  index: LocalLinkWanderIndex,
+  slug: string | undefined,
+): boolean {
+  return (
+    typeof slug === "string" && slug.length > 0 && Object.prototype.hasOwnProperty.call(index, slug)
+  )
+}
+
+export function normalizeLocalLinkWanderHref(
+  rawHref: string,
+  currentHref: string,
+  basePath: string,
+): string | undefined {
+  const href = rawHref.trim()
+  if (href.length === 0 || href.startsWith("#") || href.includes("\\")) return undefined
+
+  let current: URL
+  let candidate: URL
+  try {
+    current = new URL(currentHref)
+    candidate = new URL(href, current)
+  } catch {
+    return undefined
+  }
+
+  if (
+    candidate.origin !== current.origin ||
+    candidate.username.length > 0 ||
+    candidate.password.length > 0 ||
+    candidate.pathname === current.pathname
+  ) {
+    return undefined
+  }
+
+  const safePath = candidate.pathname.split("/").every((segment) => {
+    const decodedSeparators = segment
+      .replace(/%2e/gi, ".")
+      .replace(/%2f/gi, "/")
+      .replace(/%5c/gi, "\\")
+    return (
+      decodedSeparators !== "." &&
+      decodedSeparators !== ".." &&
+      !decodedSeparators.includes("/") &&
+      !decodedSeparators.includes("\\")
+    )
+  })
+  if (!safePath) return undefined
+
+  const normalizedBasePath = basePath === "/" ? "" : basePath.replace(/\/$/, "")
+  if (
+    normalizedBasePath.length > 0 &&
+    candidate.pathname !== normalizedBasePath &&
+    !candidate.pathname.startsWith(`${normalizedBasePath}/`)
+  ) {
+    return undefined
+  }
+
+  return `${candidate.pathname}${candidate.search}${candidate.hash}`
+}
+
+export function pickLocalLinkWanderHref(
+  rawHrefs: readonly string[],
+  currentHref: string,
+  basePath: string,
+  random: number,
+): string | undefined {
+  if (!Number.isFinite(random)) return undefined
+  const candidates = [
+    ...new Set(
+      rawHrefs
+        .map((href) => normalizeLocalLinkWanderHref(href, currentHref, basePath))
+        .filter((href): href is string => href !== undefined),
+    ),
+  ]
+  if (candidates.length === 0) return undefined
+
+  const position = Math.min(Math.max(random, 0), 1 - Number.EPSILON)
+  return candidates[Math.floor(position * candidates.length)]
+}
+
+export const localLinkWanderScript = `
+const isPublishedLocalLinkWanderSlug = ${isPublishedLocalLinkWanderSlug.toString()}
+const normalizeLocalLinkWanderHref = ${normalizeLocalLinkWanderHref.toString()}
+const pickLocalLinkWanderHref = ${pickLocalLinkWanderHref.toString()}
+
+function createLocalLinkWanderIcon() {
+  const namespace = "http://www.w3.org/2000/svg"
+  const icon = document.createElementNS(namespace, "svg")
+  icon.classList.add("local-link-wander-icon")
+  icon.setAttribute("viewBox", "0 0 24 24")
+  icon.setAttribute("aria-hidden", "true")
+  for (const d of ["M3 6h3a4 4 0 0 1 4 4v4a4 4 0 0 0 4 4h7", "m18 15 3 3-3 3"]) {
+    const path = document.createElementNS(namespace, "path")
+    path.setAttribute("d", d)
+    icon.append(path)
+  }
+  return icon
+}
+
+function collectLocalLinkWanderHrefs(article, index) {
+  return [...article.querySelectorAll("a.internal[href]")]
+    .filter(
+      (link) =>
+        !link.hasAttribute("download") &&
+        link.getClientRects().length > 0 &&
+        isPublishedLocalLinkWanderSlug(index, link.dataset.slug) &&
+        link.closest(
+          '.transclude, [data-footnote-ref], [data-footnote-backref], .footnotes, [aria-hidden="true"]',
+        ) === null,
+    )
+    .map((link) => link.getAttribute("href"))
+    .filter((href) => href !== null)
+}
+
+let cleanupCurrentLocalLinkWander = () => {}
+const cleanupLocalLinkWander = () => {
+  const cleanup = cleanupCurrentLocalLinkWander
+  cleanupCurrentLocalLinkWander = () => {}
+  cleanup()
+}
+
+function initializeLocalLinkWander() {
+  cleanupLocalLinkWander()
+  const title = document.querySelector("h1.article-title")
+  const anchor = document.querySelector(".content-meta") ?? title
+  const article = document.querySelector(".center > article.popover-hint")
+  const label = document.body.dataset.localLinkWanderLabel
+  if (
+    title === null ||
+    anchor === null ||
+    article === null ||
+    !label ||
+    typeof fetchData === "undefined"
+  ) {
+    return
+  }
+
+  let active = true
+  let link
+  let ownedRoot
+  cleanupCurrentLocalLinkWander = () => {
+    active = false
+    link?.remove()
+    ownedRoot?.remove()
+  }
+  window.addCleanup(cleanupLocalLinkWander)
+
+  fetchData.then(
+    (index) => {
+      if (!active) return
+      const href = pickLocalLinkWanderHref(
+        collectLocalLinkWanderHrefs(article, index),
+        location.href,
+        document.body.dataset.basepath ?? "",
+        Math.random(),
+      )
+      if (href === undefined) return
+
+      const existingRoot = document.querySelector("[data-read-later-root], .reader-actions")
+      const root = existingRoot ?? document.createElement("div")
+      root.classList.add("reader-actions")
+      if (existingRoot === null) {
+        ownedRoot = root
+        root.classList.add("local-link-wander-only")
+        anchor.insertAdjacentElement("afterend", root)
+      }
+
+      link = document.createElement("a")
+      link.className = "local-link-wander-link internal"
+      link.href = href
+      link.title = label
+      link.setAttribute("aria-label", label)
+      link.dataset.noPopover = ""
+      link.append(createLocalLinkWanderIcon())
+      root.prepend(link)
+    },
+    () => {
+      active = false
+    },
+  )
+}
+
+document.addEventListener("nav", initializeLocalLinkWander)
+document.addEventListener("render", initializeLocalLinkWander)
+`

--- a/quartz/components/styles/localLinkWander.scss
+++ b/quartz/components/styles/localLinkWander.scss
@@ -1,0 +1,71 @@
+.local-link-wander-only {
+  position: relative;
+  z-index: 3;
+  display: flex;
+  width: fit-content;
+  margin-block: -0.5rem 1rem;
+  margin-inline: auto 0;
+  justify-content: flex-end;
+}
+
+.local-link-wander-link {
+  display: grid;
+  box-sizing: border-box;
+  width: 2.5rem;
+  height: 2.5rem;
+  flex: 0 0 2.5rem;
+  padding: 0;
+  place-items: center;
+  border: 1px solid color-mix(in srgb, var(--gray) 54%, transparent);
+  border-radius: 6px;
+  background-color: var(--light);
+  color: var(--dark);
+  text-decoration: none;
+  touch-action: manipulation;
+  transition:
+    background-color 0.15s ease-out,
+    color 0.15s ease-out,
+    transform 0.15s ease-out;
+
+  &:hover {
+    border-color: var(--secondary);
+    background-color: var(--lightgray);
+    color: var(--secondary);
+  }
+
+  &:active {
+    transform: scale(0.96);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--secondary);
+    outline-offset: 2px;
+  }
+}
+
+.local-link-wander-icon {
+  width: 1.125rem;
+  height: 1.125rem;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 2;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .local-link-wander-link {
+    transition: none;
+
+    &:active {
+      transform: none;
+    }
+  }
+}
+
+@media print {
+  .local-link-wander-only,
+  .local-link-wander-link {
+    display: none;
+  }
+}

--- a/quartz/i18n/locales/definition.ts
+++ b/quartz/i18n/locales/definition.ts
@@ -77,6 +77,9 @@ export interface Translation {
     randomWander?: {
       title: string
     }
+    localLinkWander?: {
+      title: string
+    }
     noteShare?: {
       title: string
       shared: string

--- a/quartz/i18n/locales/en-US.ts
+++ b/quartz/i18n/locales/en-US.ts
@@ -74,6 +74,9 @@ export default {
     randomWander: {
       title: "Wander to another note",
     },
+    localLinkWander: {
+      title: "Follow a link from this note",
+    },
     noteShare: {
       title: "Share this note",
       shared: "Note shared",

--- a/quartz/i18n/locales/zh-CN.ts
+++ b/quartz/i18n/locales/zh-CN.ts
@@ -74,6 +74,9 @@ export default {
     randomWander: {
       title: "随机漫游到另一篇笔记",
     },
+    localLinkWander: {
+      title: "顺着当前笔记漫游",
+    },
     noteShare: {
       title: "分享这篇笔记",
       shared: "笔记已分享",

--- a/quartz/i18n/locales/zh-TW.ts
+++ b/quartz/i18n/locales/zh-TW.ts
@@ -71,6 +71,9 @@ export default {
     randomWander: {
       title: "隨機漫遊到另一篇筆記",
     },
+    localLinkWander: {
+      title: "順著目前筆記漫遊",
+    },
     noteShare: {
       title: "分享這篇筆記",
       shared: "筆記已分享",

--- a/quartz/plugins/emitters/componentResources.test.ts
+++ b/quartz/plugins/emitters/componentResources.test.ts
@@ -144,6 +144,24 @@ describe("componentResources", () => {
     })
   })
 
+  test("includes local-link wander when SPA navigation is disabled", () => {
+    const emitterPath = new URL("./componentResources.ts", import.meta.url)
+    const source = readFile(emitterPath, "utf8")
+
+    return source.then((contents) => {
+      const scriptIndex = contents.indexOf(
+        "componentResources.afterDOMLoaded.push(localLinkWanderScript)",
+      )
+      const styleIndex = contents.indexOf("componentResources.css.push(localLinkWanderStyle)")
+      const spaBranchIndex = contents.indexOf("if (cfg.enableSPA)")
+
+      assert.notEqual(scriptIndex, -1)
+      assert.notEqual(styleIndex, -1)
+      assert.ok(scriptIndex < spaBranchIndex)
+      assert.ok(styleIndex < spaBranchIndex)
+    })
+  })
+
   test("includes wide-content scroll cues when SPA navigation is disabled", () => {
     const emitterPath = new URL("./componentResources.ts", import.meta.url)
     const source = readFile(emitterPath, "utf8")

--- a/quartz/plugins/emitters/componentResources.ts
+++ b/quartz/plugins/emitters/componentResources.ts
@@ -24,6 +24,8 @@ import { randomWanderScript } from "../../components/scripts/randomWander"
 import randomWanderStyle from "../../components/styles/randomWander.scss"
 import { noteShareScript } from "../../components/scripts/noteShare"
 import noteShareStyle from "../../components/styles/noteShare.scss"
+import { localLinkWanderScript } from "../../components/scripts/localLinkWander"
+import localLinkWanderStyle from "../../components/styles/localLinkWander.scss"
 import { wideContentScrollScript } from "../../components/scripts/wideContentScroll"
 import wideContentScrollStyle from "../../components/styles/wideContentScroll.scss"
 import { BuildCtx } from "../../util/ctx"
@@ -116,6 +118,8 @@ function addGlobalPageResources(ctx: BuildCtx, componentResources: ComponentReso
   componentResources.css.push(randomWanderStyle)
   componentResources.afterDOMLoaded.push(noteShareScript)
   componentResources.css.push(noteShareStyle)
+  componentResources.afterDOMLoaded.push(localLinkWanderScript)
+  componentResources.css.push(localLinkWanderStyle)
   componentResources.afterDOMLoaded.push(wideContentScrollScript)
   componentResources.css.push(wideContentScrollStyle)
 


### PR DESCRIPTION
Built a localized "follow a link from this note" reader action that randomly selects only visible, published internal links authored in the current article. It feels worth merging because it turns the garden's link graph into a one-click contextual walk: readers keep following the thread they are already on instead of jumping randomly across the whole collection, while broken links and unsafe destinations never become dead ends.

## Verification

- `npx tsx --test quartz/components/scripts/localLinkWander.test.ts quartz/plugins/emitters/componentResources.test.ts` (15/15 passed)
- `npx tsc --noEmit`
- Scoped Prettier check for every changed TypeScript/SCSS file
- `git diff --check`
- `npx quartz build` (314 inputs, 1912 outputs)
- `npm test` (238/239 passed; the only failure is the existing undeclared `jsdom` import in `local-plugins/theme-switcher/test/themeSwitcherScript.test.ts`)
- Real Chromium QA at 1280x900 and 390x844 covered visible published candidates, broken-link exclusion, native link semantics, a successful SPA hop, the published no-candidate state, back navigation, repeated `render` events, focus-visible, dark mode, reduced motion, and viewport containment with zero browser errors

## Impact

- Adds one dependency-free reader script, focused tests, and scoped styles
- Reuses Quartz's existing content-index promise; no new requests, storage, analytics, or content writes
- Adds English, Simplified Chinese, and Traditional Chinese labels with the existing locale fallback pattern
- Does not change content, dependencies, lockfiles, configuration, CI, deployment, permissions, or infrastructure
- Related: #24. This action avoids unpublished/broken wikilinks as destinations, but deliberately does not close the underlying broken-link rendering issue.

## Rollback

Revert commit `8ca225f4` to remove the action, its resource registration, labels, tests, styles, and design contract without data migration or persistent-state cleanup.
