### PR TITLE
fix(search): localize empty state for zh-CN

### DIFF
--- a/quartz/components/renderPage.tsx
+++ b/quartz/components/renderPage.tsx
@@ -373,6 +373,11 @@ export function renderPage(
   const randomWander = i18n(pageLocale).components.randomWander ?? fallbackRandomWander
   const fallbackNoteShare = TRANSLATIONS[defaultTranslation].components.noteShare
   const noteShare = i18n(pageLocale).components.noteShare ?? fallbackNoteShare
+  const fallbackSearch = TRANSLATIONS[defaultTranslation].components.search
+  const searchI18n = i18n(pageLocale).components.search
+  const searchNoResults = searchI18n.noResults ?? fallbackSearch.noResults ?? "No results."
+  const searchNoResultsHint =
+    searchI18n.noResultsHint ?? fallbackSearch.noResultsHint ?? "Try another search term?"
   const fallbackWideContentScroll = TRANSLATIONS[defaultTranslation].components.wideContentScroll
   const wideContentScroll =
     i18n(pageLocale).components.wideContentScroll ?? fallbackWideContentScroll
@@ -413,6 +418,8 @@ export function renderPage(
         data-note-share-shared={noteShare.shared}
         data-note-share-copied={noteShare.copied}
         data-note-share-failed={noteShare.failed}
+        data-search-no-results={searchNoResults}
+        data-search-no-results-hint={searchNoResultsHint}
         data-wide-content-table={wideContentScroll.table}
         data-wide-content-code={wideContentScroll.code}
       >

--- a/quartz/components/scripts/search.test.ts
+++ b/quartz/components/scripts/search.test.ts
@@ -1,4 +1,6 @@
 import test, { describe } from "node:test"
+import { i18n } from "../../i18n"
+import { applySearchEmptyState, searchEmptyStateLabels } from "./searchEmptyState"
 import assert from "node:assert"
 
 // Inline the encoder function from search.inline.ts for testing
@@ -159,5 +161,92 @@ describe("search encoder", () => {
       const result = encoder("hello  ")
       assert.deepStrictEqual(result, ["hello"])
     })
+  })
+})
+
+describe("search empty state i18n", () => {
+  test("zh-CN uses the garden empty-state copy", () => {
+    // Given
+    const locale = "zh-CN"
+
+    // When
+    const search = i18n(locale).components.search
+
+    // Then
+    assert.equal(search.noResults, "没有找到相关笔记")
+    assert.equal(search.noResultsHint, "换个关键词试试？")
+  })
+
+  test("en-US keeps the English empty-state copy", () => {
+    // Given
+    const locale = "en-US"
+
+    // When
+    const search = i18n(locale).components.search
+
+    // Then
+    assert.equal(search.noResults, "No results.")
+    assert.equal(search.noResultsHint, "Try another search term?")
+  })
+
+  test("reads labels rendered by Quartz i18n", () => {
+    // Given
+    const dataset = {
+      searchNoResults: "没有找到相关笔记",
+      searchNoResultsHint: "换个关键词试试？",
+    } as DOMStringMap
+
+    // When
+    const labels = searchEmptyStateLabels(dataset)
+
+    // Then
+    assert.deepEqual(labels, {
+      noResults: "没有找到相关笔记",
+      noResultsHint: "换个关键词试试？",
+    })
+  })
+
+  test("does not bind when rendered labels are incomplete", () => {
+    // Given
+    const dataset = {
+      searchNoResults: "没有找到相关笔记",
+    } as DOMStringMap
+
+    // When
+    const labels = searchEmptyStateLabels(dataset)
+
+    // Then
+    assert.strictEqual(labels, undefined)
+  })
+
+  test("localizes the empty-state card without touching matches", () => {
+    // Given
+    const matchTitle = { textContent: "Obsidian Flight School" }
+    const emptyTitle = { textContent: "No results." }
+    const emptyHint = { textContent: "Try another search term?" }
+    const labels = {
+      noResults: "没有找到相关笔记",
+      noResultsHint: "换个关键词试试？",
+    }
+    const root = {
+      querySelectorAll(selector: string) {
+        assert.equal(selector, ".result-card.no-match")
+        return [
+          {
+            querySelector(sel: string) {
+              return sel === "h3" ? emptyTitle : emptyHint
+            },
+          },
+        ]
+      },
+    }
+
+    // When
+    applySearchEmptyState(root, labels)
+
+    // Then
+    assert.equal(emptyTitle.textContent, "没有找到相关笔记")
+    assert.equal(emptyHint.textContent, "换个关键词试试？")
+    assert.equal(matchTitle.textContent, "Obsidian Flight School")
   })
 })

--- a/quartz/components/scripts/search.test.ts
+++ b/quartz/components/scripts/search.test.ts
@@ -249,4 +249,56 @@ describe("search empty state i18n", () => {
     assert.equal(emptyHint.textContent, "换个关键词试试？")
     assert.equal(matchTitle.textContent, "Obsidian Flight School")
   })
+
+  test("writes localized empty-state copy only when the text changed", () => {
+    // Given
+    let titleWrites = 0
+    let hintWrites = 0
+    const emptyTitle = {
+      current: "No results.",
+      get textContent() {
+        return this.current
+      },
+      set textContent(value: string) {
+        titleWrites += 1
+        this.current = value
+      },
+    }
+    const emptyHint = {
+      current: "Try another search term?",
+      get textContent() {
+        return this.current
+      },
+      set textContent(value: string) {
+        hintWrites += 1
+        this.current = value
+      },
+    }
+    const labels = {
+      noResults: "没有找到相关笔记",
+      noResultsHint: "换个关键词试试？",
+    }
+    const root = {
+      querySelectorAll(selector: string) {
+        assert.equal(selector, ".result-card.no-match")
+        return [
+          {
+            querySelector(sel: string) {
+              return sel === "h3" ? emptyTitle : emptyHint
+            },
+          },
+        ]
+      },
+    }
+
+    // When
+    applySearchEmptyState(root, labels)
+    applySearchEmptyState(root, labels)
+
+    // Then
+    assert.equal(titleWrites, 1)
+    assert.equal(hintWrites, 1)
+    assert.equal(emptyTitle.textContent, "没有找到相关笔记")
+    assert.equal(emptyHint.textContent, "换个关键词试试？")
+  })
 })

--- a/quartz/components/scripts/search.test.ts
+++ b/quartz/components/scripts/search.test.ts
@@ -189,6 +189,18 @@ describe("search empty state i18n", () => {
     assert.equal(search.noResultsHint, "Try another search term?")
   })
 
+  test("zh-TW preserves the existing fallback empty state", () => {
+    // Given
+    const locale = "zh-TW"
+
+    // When
+    const search = i18n(locale).components.search
+
+    // Then
+    assert.equal(search.noResults, undefined)
+    assert.equal(search.noResultsHint, undefined)
+  })
+
   test("reads labels rendered by Quartz i18n", () => {
     // Given
     const dataset = {

--- a/quartz/components/scripts/searchEmptyState.ts
+++ b/quartz/components/scripts/searchEmptyState.ts
@@ -25,8 +25,12 @@ export function applySearchEmptyState(root: EmptyStateRoot, labels: SearchEmptyS
     if (!card) continue
     const title = card.querySelector("h3")
     const hint = card.querySelector("p")
-    if (title) title.textContent = labels.noResults
-    if (hint) hint.textContent = labels.noResultsHint
+    if (title && title.textContent !== labels.noResults) {
+      title.textContent = labels.noResults
+    }
+    if (hint && hint.textContent !== labels.noResultsHint) {
+      hint.textContent = labels.noResultsHint
+    }
   }
 }
 

--- a/quartz/components/scripts/searchEmptyState.ts
+++ b/quartz/components/scripts/searchEmptyState.ts
@@ -1,0 +1,62 @@
+export type SearchEmptyStateLabels = Readonly<{
+  noResults: string
+  noResultsHint: string
+}>
+
+export function searchEmptyStateLabels(dataset: DOMStringMap): SearchEmptyStateLabels | undefined {
+  const { searchNoResults: noResults, searchNoResultsHint: noResultsHint } = dataset
+  if (!noResults || !noResultsHint) return
+
+  return { noResults, noResultsHint }
+}
+
+type EmptyStateNode = {
+  querySelector(selector: string): { textContent: string } | null
+}
+
+type EmptyStateRoot = {
+  querySelectorAll(selector: string): ArrayLike<EmptyStateNode>
+}
+
+export function applySearchEmptyState(root: EmptyStateRoot, labels: SearchEmptyStateLabels): void {
+  const cards = root.querySelectorAll(".result-card.no-match")
+  for (let i = 0; i < cards.length; i++) {
+    const card = cards[i]
+    if (!card) continue
+    const title = card.querySelector("h3")
+    const hint = card.querySelector("p")
+    if (title) title.textContent = labels.noResults
+    if (hint) hint.textContent = labels.noResultsHint
+  }
+}
+
+export const searchEmptyStateScript = `
+const searchEmptyStateLabels = ${searchEmptyStateLabels.toString()}
+const applySearchEmptyState = ${applySearchEmptyState.toString()}
+
+let searchEmptyStateObserver
+
+function localizeSearchEmptyState() {
+  const labels = searchEmptyStateLabels(document.body.dataset)
+  if (!labels) return
+  applySearchEmptyState(document, labels)
+}
+
+function bindSearchEmptyState() {
+  localizeSearchEmptyState()
+  if (typeof MutationObserver === "undefined") return
+  if (searchEmptyStateObserver) searchEmptyStateObserver.disconnect()
+  searchEmptyStateObserver = new MutationObserver(() => localizeSearchEmptyState())
+  const targets = document.querySelectorAll(".search-layout, .results-container")
+  if (targets.length === 0) {
+    searchEmptyStateObserver.observe(document.body, { childList: true, subtree: true })
+    return
+  }
+  for (const target of targets) {
+    searchEmptyStateObserver.observe(target, { childList: true, subtree: true })
+  }
+}
+
+document.addEventListener("nav", bindSearchEmptyState)
+document.addEventListener("render", bindSearchEmptyState)
+`

--- a/quartz/i18n/locales/definition.ts
+++ b/quartz/i18n/locales/definition.ts
@@ -107,6 +107,8 @@ export interface Translation {
     search: {
       title: string
       searchBarPlaceholder: string
+      noResults?: string
+      noResultsHint?: string
     }
     tableOfContents: {
       title: string

--- a/quartz/i18n/locales/en-US.ts
+++ b/quartz/i18n/locales/en-US.ts
@@ -104,6 +104,8 @@ export default {
     search: {
       title: "Search",
       searchBarPlaceholder: "Search for something",
+      noResults: "No results.",
+      noResultsHint: "Try another search term?",
     },
     tableOfContents: {
       title: "Table of Contents",

--- a/quartz/i18n/locales/zh-CN.ts
+++ b/quartz/i18n/locales/zh-CN.ts
@@ -104,6 +104,8 @@ export default {
     search: {
       title: "搜索",
       searchBarPlaceholder: "搜索些什么",
+      noResults: "没有找到相关笔记",
+      noResultsHint: "换个关键词试试？",
     },
     tableOfContents: {
       title: "目录",

--- a/quartz/i18n/locales/zh-TW.ts
+++ b/quartz/i18n/locales/zh-TW.ts
@@ -101,8 +101,6 @@ export default {
     search: {
       title: "搜尋",
       searchBarPlaceholder: "搜尋些什麼",
-      noResults: "沒有找到相關筆記",
-      noResultsHint: "換個關鍵詞試試？",
     },
     tableOfContents: {
       title: "目錄",

--- a/quartz/i18n/locales/zh-TW.ts
+++ b/quartz/i18n/locales/zh-TW.ts
@@ -101,6 +101,8 @@ export default {
     search: {
       title: "搜尋",
       searchBarPlaceholder: "搜尋些什麼",
+      noResults: "沒有找到相關筆記",
+      noResultsHint: "換個關鍵詞試試？",
     },
     tableOfContents: {
       title: "目錄",

--- a/quartz/plugins/emitters/componentResources.ts
+++ b/quartz/plugins/emitters/componentResources.ts
@@ -25,6 +25,7 @@ import randomWanderStyle from "../../components/styles/randomWander.scss"
 import { noteShareScript } from "../../components/scripts/noteShare"
 import noteShareStyle from "../../components/styles/noteShare.scss"
 import { wideContentScrollScript } from "../../components/scripts/wideContentScroll"
+import { searchEmptyStateScript } from "../../components/scripts/searchEmptyState"
 import wideContentScrollStyle from "../../components/styles/wideContentScroll.scss"
 import { BuildCtx } from "../../util/ctx"
 import { QuartzComponent } from "../../components/types"
@@ -117,6 +118,7 @@ function addGlobalPageResources(ctx: BuildCtx, componentResources: ComponentReso
   componentResources.afterDOMLoaded.push(noteShareScript)
   componentResources.css.push(noteShareStyle)
   componentResources.afterDOMLoaded.push(wideContentScrollScript)
+  componentResources.afterDOMLoaded.push(searchEmptyStateScript)
   componentResources.css.push(wideContentScrollStyle)
 
   // popovers


### PR DESCRIPTION
Closes #25

## Summary
- Add search empty-state i18n strings: zh-CN `没有找到相关笔记` / `换个关键词试试？`, en-US keeps `No results.` / `Try another search term?`.
- Render those strings on `<body>` (`data-search-no-results`, `data-search-no-results-hint`) following the existing heading-permalink / note-share pattern.
- Wire the community search plugin's hardcoded English empty card (`.result-card.no-match`) to those labels without changing matching result cards.

## Test plan
- [ ] `npx tsx --test quartz/components/scripts/search.test.ts` (26 passed locally)
- [ ] Open a garden page, search `zzzzqwxnotfound999`, empty state is Chinese and no longer shows `No results.` / `Try another search term?`
- [ ] Search `obsidian` still shows result cards
- [ ] English locale still uses the English empty state