### PR TITLE
feat(reader): fold long code blocks

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -236,6 +236,13 @@ Layout rules:
 - **Accessibility**: The native button and polite live region use page-localized names. Keyboard activation, a stable 40px target, print hiding, and Quartz SPA `nav`/`render` cleanup are required.
 - **Motion**: Existing 150ms micro transitions cover hover and press feedback. Reduced-motion removes transitions and spatial press feedback.
 
+### CodeFolding
+
+- **Structure**: Syntax-highlighted, non-Mermaid code blocks longer than 24 rendered lines receive one compact chevron control beside the existing copy action. Short and plain code blocks remain untouched.
+- **Behavior**: Long blocks begin at a bounded reading height and expand in place without moving or rewriting code. No-JavaScript and print output always expose the complete source; SPA navigation and in-place render cleanup never duplicate controls.
+- **Accessibility**: The native button reports localized expand/collapse names, `aria-expanded`, and its controlled code region. Keyboard focus remains on the action while state changes, with the existing opaque 2px focus ring.
+- **Motion**: Expand and collapse are immediate. Control feedback uses the 150ms micro transition; reduced motion removes transitions and press scaling, and no scroll or layout animation is introduced.
+
 ## 6. Motion & Interaction
 
 Motion is quiet utility feedback, not brand theater.

--- a/quartz/components/renderPage.tsx
+++ b/quartz/components/renderPage.tsx
@@ -390,6 +390,8 @@ export function renderPage(
     i18n(pageLocale).components.wideContentScroll ?? fallbackWideContentScroll
   const fallbackTableMarkdown = TRANSLATIONS[defaultTranslation].components.tableMarkdown
   const tableMarkdown = i18n(pageLocale).components.tableMarkdown ?? fallbackTableMarkdown
+  const fallbackCodeFolding = TRANSLATIONS[defaultTranslation].components.codeFolding
+  const codeFolding = i18n(pageLocale).components.codeFolding ?? fallbackCodeFolding
   // During local dev (--serve), the dev server serves from root without the
   // baseUrl subpath, so basePath must be empty to avoid broken links.
   const basePath =
@@ -444,6 +446,8 @@ export function renderPage(
         data-table-markdown-title={tableMarkdown.title}
         data-table-markdown-copied={tableMarkdown.copied}
         data-table-markdown-failed={tableMarkdown.failed}
+        data-code-folding-expand={codeFolding.expand}
+        data-code-folding-collapse={codeFolding.collapse}
       >
         {frame.css && <style dangerouslySetInnerHTML={{ __html: frame.css }} />}
         <div id="quartz-root" class="page" data-frame={frame.name}>

--- a/quartz/components/scripts/codeFolding.test.ts
+++ b/quartz/components/scripts/codeFolding.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert"
+import test, { describe } from "node:test"
+import enUs from "../../i18n/locales/en-US"
+import zhCn from "../../i18n/locales/zh-CN"
+import zhTw from "../../i18n/locales/zh-TW"
+import {
+  CODE_FOLDING_MIN_LINES,
+  codeFoldingLabels,
+  codeFoldingLineCount,
+  codeFoldingScript,
+  shouldFoldCodeBlock,
+} from "./codeFolding"
+
+describe("code folding eligibility", () => {
+  test("counts plain and trailing-newline source accurately", () => {
+    assert.equal(codeFoldingLineCount("one\ntwo\nthree"), 3)
+    assert.equal(codeFoldingLineCount("one\ntwo\nthree\n"), 3)
+    assert.equal(codeFoldingLineCount(""), 0)
+  })
+
+  test("prefers rendered syntax-highlighted lines", () => {
+    assert.equal(codeFoldingLineCount("visually transformed", 31), 31)
+  })
+
+  test("folds only beyond the minimum line count", () => {
+    const minimum = Array.from({ length: CODE_FOLDING_MIN_LINES }, (_, index) => `${index}`).join(
+      "\n",
+    )
+    const long = `${minimum}\n${CODE_FOLDING_MIN_LINES}`
+
+    assert.equal(shouldFoldCodeBlock(minimum), false)
+    assert.equal(shouldFoldCodeBlock(long), true)
+  })
+})
+
+describe("code folding labels", () => {
+  test("reads complete rendered labels", () => {
+    assert.deepEqual(
+      codeFoldingLabels({
+        codeFoldingExpand: "Expand code block",
+        codeFoldingCollapse: "Collapse code block",
+      } as DOMStringMap),
+      { expand: "Expand code block", collapse: "Collapse code block" },
+    )
+  })
+
+  test("does not initialize with an incomplete label set", () => {
+    assert.equal(
+      codeFoldingLabels({ codeFoldingExpand: "Expand code block" } as DOMStringMap),
+      undefined,
+    )
+  })
+})
+
+test("code folding browser script compiles and follows Quartz lifecycle", () => {
+  assert.doesNotThrow(() => new Function(codeFoldingScript))
+  assert.doesNotMatch(codeFoldingScript, /\ninitializeCodeFolding\(\)\n/)
+  assert.match(codeFoldingScript, /document\.addEventListener\("nav", initializeCodeFolding\)/)
+  assert.match(codeFoldingScript, /document\.addEventListener\("render", initializeCodeFolding\)/)
+  assert.match(codeFoldingScript, /window\.addCleanup\(cleanupCodeFolding\)/)
+  assert.match(codeFoldingScript, /code:not\(\.mermaid\)/)
+  assert.match(codeFoldingScript, /button\.removeEventListener\("click", toggle\)/)
+})
+
+test("code folding labels use the central locale catalog", () => {
+  assert.equal(enUs.components.codeFolding.expand, "Expand code block")
+  assert.equal(zhCn.components.codeFolding.collapse, "收起代码块")
+  assert.equal(zhTw.components.codeFolding.expand, "展開程式碼區塊")
+})

--- a/quartz/components/scripts/codeFolding.ts
+++ b/quartz/components/scripts/codeFolding.ts
@@ -1,0 +1,130 @@
+export const CODE_FOLDING_MIN_LINES = 24
+
+export function codeFoldingLineCount(source: string, renderedLineCount = 0): number {
+  if (Number.isInteger(renderedLineCount) && renderedLineCount > 0) return renderedLineCount
+
+  const normalized = source.replace(/\r\n?/g, "\n").replace(/\n$/, "")
+  return normalized === "" ? 0 : normalized.split("\n").length
+}
+
+export function shouldFoldCodeBlock(source: string, renderedLineCount = 0): boolean {
+  return codeFoldingLineCount(source, renderedLineCount) > CODE_FOLDING_MIN_LINES
+}
+
+export type CodeFoldingLabels = {
+  readonly expand: string
+  readonly collapse: string
+}
+
+export function codeFoldingLabels(dataset: DOMStringMap): CodeFoldingLabels | undefined {
+  const { codeFoldingExpand: expand, codeFoldingCollapse: collapse } = dataset
+  if (!expand || !collapse) return undefined
+  return { expand, collapse }
+}
+
+export const codeFoldingScript = `
+const codeFoldingLineCount = ${codeFoldingLineCount.toString()}
+const shouldFoldCodeBlock = ${shouldFoldCodeBlock.toString()}
+const codeFoldingLabels = ${codeFoldingLabels.toString()}
+const CODE_FOLDING_MIN_LINES = ${CODE_FOLDING_MIN_LINES}
+
+function createCodeFoldingIcon(expanded) {
+  const namespace = "http://www.w3.org/2000/svg"
+  const icon = document.createElementNS(namespace, "svg")
+  icon.classList.add("code-folding-icon")
+  icon.setAttribute("viewBox", "0 0 24 24")
+  icon.setAttribute("fill", "none")
+  icon.setAttribute("stroke", "currentColor")
+  icon.setAttribute("stroke-width", "2")
+  icon.setAttribute("stroke-linecap", "round")
+  icon.setAttribute("stroke-linejoin", "round")
+  icon.setAttribute("aria-hidden", "true")
+  const path = document.createElementNS(namespace, "path")
+  path.setAttribute("d", expanded ? "m18 15-6-6-6 6" : "m6 9 6 6 6-6")
+  icon.append(path)
+  return icon
+}
+
+let cleanupCurrentCodeFolding = () => {}
+const cleanupCodeFolding = () => {
+  const cleanup = cleanupCurrentCodeFolding
+  cleanupCurrentCodeFolding = () => {}
+  cleanup()
+}
+
+function initializeCodeFolding() {
+  cleanupCodeFolding()
+  const labels = codeFoldingLabels(document.body.dataset)
+  if (labels === undefined) return
+
+  const codeBlocks = Array.from(
+    document.querySelectorAll(
+      "article figure[data-rehype-pretty-code-figure] > pre > code:not(.mermaid)",
+    ),
+  ).filter((code) => code instanceof HTMLElement)
+  const cleanups = []
+
+  for (let index = 0; index < codeBlocks.length; index += 1) {
+    const code = codeBlocks[index]
+    const pre = code.parentElement
+    if (pre === null || pre.tagName !== "PRE") continue
+
+    const renderedLineCount = code.querySelectorAll("[data-line]").length
+    if (!shouldFoldCodeBlock(code.textContent ?? "", renderedLineCount)) continue
+
+    const originalId = pre.getAttribute("id")
+    const hadBlockClass = pre.classList.contains("code-folding-block")
+    const hadCollapsedClass = pre.classList.contains("code-folding-collapsed")
+    if (pre.id === "") {
+      let suffix = index + 1
+      let candidate = "code-folding-" + suffix
+      while (document.getElementById(candidate) !== null) {
+        suffix += 1
+        candidate = "code-folding-" + suffix
+      }
+      pre.id = candidate
+    }
+
+    const button = document.createElement("button")
+    button.type = "button"
+    button.className = "code-folding-trigger"
+    button.setAttribute("aria-controls", pre.id)
+    pre.classList.add("code-folding-block")
+
+    let expanded = false
+    const renderState = () => {
+      const label = expanded ? labels.collapse : labels.expand
+      pre.classList.toggle("code-folding-collapsed", !expanded)
+      button.setAttribute("aria-expanded", String(expanded))
+      button.setAttribute("aria-label", label)
+      button.title = label
+      button.replaceChildren(createCodeFoldingIcon(expanded))
+    }
+    const toggle = () => {
+      expanded = !expanded
+      renderState()
+    }
+
+    button.addEventListener("click", toggle)
+    pre.prepend(button)
+    renderState()
+
+    cleanups.push(() => {
+      button.removeEventListener("click", toggle)
+      button.remove()
+      pre.classList.toggle("code-folding-block", hadBlockClass)
+      pre.classList.toggle("code-folding-collapsed", hadCollapsedClass)
+      if (originalId === null) pre.removeAttribute("id")
+      else pre.setAttribute("id", originalId)
+    })
+  }
+
+  cleanupCurrentCodeFolding = () => {
+    for (const cleanup of cleanups) cleanup()
+  }
+  window.addCleanup(cleanupCodeFolding)
+}
+
+document.addEventListener("nav", initializeCodeFolding)
+document.addEventListener("render", initializeCodeFolding)
+`

--- a/quartz/components/styles/codeFolding.scss
+++ b/quartz/components/styles/codeFolding.scss
@@ -1,0 +1,88 @@
+pre.code-folding-block {
+  &.code-folding-collapsed {
+    max-height: min(30rem, 58vh);
+    overflow-y: hidden;
+
+    &::after {
+      content: "";
+      position: absolute;
+      z-index: 1;
+      inset-inline: 0;
+      bottom: 0;
+      height: 4.5rem;
+      pointer-events: none;
+      background: linear-gradient(
+        to bottom,
+        transparent,
+        color-mix(in srgb, var(--light) 94%, transparent)
+      );
+    }
+  }
+
+  & > .code-folding-trigger {
+    position: absolute;
+    z-index: 2;
+    top: 0.3rem;
+    inset-inline-end: 2.85rem;
+    display: grid;
+    width: 2rem;
+    height: 2rem;
+    padding: 0;
+    place-items: center;
+    color: var(--gray);
+    background: var(--light);
+    border: 1px solid var(--dark);
+    border-radius: 5px;
+    opacity: 0.82;
+    transition:
+      color 0.15s ease-out,
+      background-color 0.15s ease-out,
+      border-color 0.15s ease-out,
+      opacity 0.15s ease-out,
+      transform 0.15s ease-out;
+
+    &:hover {
+      color: var(--secondary);
+      background: var(--lightgray);
+      border-color: var(--secondary);
+      cursor: pointer;
+      opacity: 1;
+    }
+
+    &:active {
+      transform: scale(0.93);
+    }
+
+    &:focus-visible {
+      outline: 2px solid var(--secondary);
+      outline-offset: 2px;
+      opacity: 1;
+    }
+
+    & > .code-folding-icon {
+      width: 1rem;
+      height: 1rem;
+    }
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  pre.code-folding-block > .code-folding-trigger {
+    transition: none;
+  }
+
+  pre.code-folding-block > .code-folding-trigger:active {
+    transform: none;
+  }
+}
+
+@media print {
+  pre.code-folding-block {
+    max-height: none !important;
+
+    &::after,
+    & > .code-folding-trigger {
+      display: none;
+    }
+  }
+}

--- a/quartz/i18n/locales/definition.ts
+++ b/quartz/i18n/locales/definition.ts
@@ -101,6 +101,10 @@ export interface Translation {
       copied: string
       failed: string
     }
+    codeFolding?: {
+      expand: string
+      collapse: string
+    }
     explorer: {
       title: string
     }

--- a/quartz/i18n/locales/en-US.ts
+++ b/quartz/i18n/locales/en-US.ts
@@ -98,6 +98,10 @@ export default {
       copied: "Table Markdown copied",
       failed: "The browser could not copy this table",
     },
+    codeFolding: {
+      expand: "Expand code block",
+      collapse: "Collapse code block",
+    },
     explorer: {
       title: "Explorer",
     },

--- a/quartz/i18n/locales/zh-CN.ts
+++ b/quartz/i18n/locales/zh-CN.ts
@@ -98,6 +98,10 @@ export default {
       copied: "表格 Markdown 已复制",
       failed: "浏览器未能复制表格",
     },
+    codeFolding: {
+      expand: "展开代码块",
+      collapse: "收起代码块",
+    },
     explorer: {
       title: "探索",
     },

--- a/quartz/i18n/locales/zh-TW.ts
+++ b/quartz/i18n/locales/zh-TW.ts
@@ -95,6 +95,10 @@ export default {
       copied: "表格 Markdown 已複製",
       failed: "瀏覽器未能複製表格",
     },
+    codeFolding: {
+      expand: "展開程式碼區塊",
+      collapse: "收合程式碼區塊",
+    },
     explorer: {
       title: "探索",
     },

--- a/quartz/plugins/emitters/componentResources.test.ts
+++ b/quartz/plugins/emitters/componentResources.test.ts
@@ -198,6 +198,7 @@ describe("componentResources", () => {
     })
   })
 
+
   test("includes table Markdown copying when SPA navigation is disabled", () => {
     const emitterPath = new URL("./componentResources.ts", import.meta.url)
     const source = readFile(emitterPath, "utf8")
@@ -207,6 +208,24 @@ describe("componentResources", () => {
         "componentResources.afterDOMLoaded.push(tableMarkdownScript)",
       )
       const styleIndex = contents.indexOf("componentResources.css.push(tableMarkdownStyle)")
+      const spaBranchIndex = contents.indexOf("if (cfg.enableSPA)")
+
+      assert.notEqual(scriptIndex, -1)
+      assert.notEqual(styleIndex, -1)
+      assert.ok(scriptIndex < spaBranchIndex)
+      assert.ok(styleIndex < spaBranchIndex)
+    })
+  })
+
+  test("includes code folding when SPA navigation is disabled", () => {
+    const emitterPath = new URL("./componentResources.ts", import.meta.url)
+    const source = readFile(emitterPath, "utf8")
+
+    return source.then((contents) => {
+      const scriptIndex = contents.indexOf(
+        "componentResources.afterDOMLoaded.push(codeFoldingScript)",
+      )
+      const styleIndex = contents.indexOf("componentResources.css.push(codeFoldingStyle)")
       const spaBranchIndex = contents.indexOf("if (cfg.enableSPA)")
 
       assert.notEqual(scriptIndex, -1)

--- a/quartz/plugins/emitters/componentResources.ts
+++ b/quartz/plugins/emitters/componentResources.ts
@@ -32,6 +32,8 @@ import searchFeedbackStyle from "../../components/styles/searchFeedback.scss"
 import wideContentScrollStyle from "../../components/styles/wideContentScroll.scss"
 import { tableMarkdownScript } from "../../components/scripts/tableMarkdown"
 import tableMarkdownStyle from "../../components/styles/tableMarkdown.scss"
+import { codeFoldingScript } from "../../components/scripts/codeFolding"
+import codeFoldingStyle from "../../components/styles/codeFolding.scss"
 import { BuildCtx } from "../../util/ctx"
 import { QuartzComponent } from "../../components/types"
 import { normalizeResource } from "../../util/resources"
@@ -130,6 +132,8 @@ function addGlobalPageResources(ctx: BuildCtx, componentResources: ComponentReso
   componentResources.css.push(wideContentScrollStyle)
   componentResources.afterDOMLoaded.push(tableMarkdownScript)
   componentResources.css.push(tableMarkdownStyle)
+  componentResources.afterDOMLoaded.push(codeFoldingScript)
+  componentResources.css.push(codeFoldingStyle)
 
   // popovers
   if (cfg.enablePopovers) {


### PR DESCRIPTION
Long syntax-highlighted code blocks now start at a compact reading height and expand in place from a localized chevron beside the existing copy control, while short blocks, Mermaid diagrams, no-JavaScript output, and print output stay untouched. It is worth merging because dense technical notes become easier to scan without sacrificing source access, keyboard accessibility, or the existing copy and horizontal-scroll workflows.

## Validation

- `npx tsx --test quartz/components/scripts/codeFolding.test.ts quartz/plugins/emitters/componentResources.test.ts` (15/15 passed)
- `npx tsc --noEmit`
- Scoped Prettier check and `git diff --check`
- `npx quartz build` (314 Markdown inputs, 1912 outputs)
- Real Chromium QA at 1280x900 and 390x844: expand/collapse, keyboard focus, copy-button coexistence, dark mode, reduced motion, responsive overflow, and SPA singleton cleanup
- Full `npm test`: 241/242 passed; the sole failure is the existing undeclared `jsdom` import in untouched `local-plugins/theme-switcher/test/themeSwitcherScript.test.ts`

## Impact

- Adds a reader-only control for syntax-highlighted code blocks longer than 24 rendered lines
- Adds localized labels for English, Simplified Chinese, and Traditional Chinese, with the existing locale fallback for other languages
- No content, dependency, configuration, storage, network, deployment, or infrastructure changes

## Rollback

Revert commit `69f9b49be3fff608f282b4caf5ae48ee57dcc0eb`. Static HTML always retains the full code content, so rollback has no content migration or data cleanup.

## Hosted status

Netlify deploy preview `6a93410fa2fce600089f403e` failed all four contexts with an unavailable public summary, no messages, and zero GitHub annotations. Merged baseline PR #29 has the same four-context failure pattern, while this exact SHA passes the local production build and browser QA above. No deployment, configuration, authentication, or infrastructure changes were made.
