### PR TITLE
fix(callout): strip title continuation backslash

### DIFF
--- a/quartz/processors/parse.ts
+++ b/quartz/processors/parse.ts
@@ -14,6 +14,7 @@ import { QuartzLogger } from "../util/log"
 import { trace } from "../util/trace"
 import { BuildCtx, WorkerSerializableBuildCtx } from "../util/ctx"
 import { styleText } from "util"
+import { stripCalloutTitleContinuationsInMarkdown } from "../util/calloutTitle"
 
 export type QuartzMdProcessor = Processor<MDRoot, MDRoot, MDRoot>
 export type QuartzHtmlProcessor = Processor<undefined, MDRoot, HTMLRoot>
@@ -98,6 +99,8 @@ export function createFileParser(ctx: BuildCtx, fps: FilePath[]) {
         for (const plugin of cfg.plugins.transformers.filter((p) => p.textTransform)) {
           file.value = plugin.textTransform!(ctx, file.value.toString())
         }
+
+        file.value = stripCalloutTitleContinuationsInMarkdown(file.value.toString())
 
         // base data properties that plugins may use
         file.data.filePath = file.path as FilePath

--- a/quartz/util/calloutTitle.test.ts
+++ b/quartz/util/calloutTitle.test.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert"
+import test, { describe } from "node:test"
+import {
+  stripCalloutTitleContinuation,
+  stripCalloutTitleContinuationsInMarkdown,
+} from "./calloutTitle"
+
+describe("stripCalloutTitleContinuation", () => {
+  test("drops a trailing continuation backslash", () => {
+    assert.equal(stripCalloutTitleContinuation(" 提示\\"), " 提示")
+    assert.equal(stripCalloutTitleContinuation("提示\\"), "提示")
+    assert.equal(stripCalloutTitleContinuation("\\"), "")
+  })
+
+  test("leaves titles without a trailing backslash alone", () => {
+    assert.equal(stripCalloutTitleContinuation(" 提示"), " 提示")
+    assert.equal(stripCalloutTitleContinuation("C:\\Windows"), "C:\\Windows")
+  })
+})
+
+describe("stripCalloutTitleContinuationsInMarkdown", () => {
+  test("strips INFO title continuation and keeps the body line", () => {
+    const src = "> [!INFO] 提示\\\n> 这里是正文\n"
+    const out = stripCalloutTitleContinuationsInMarkdown(src)
+    assert.equal(out, "> [!INFO] 提示\n> 这里是正文\n")
+  })
+
+  test("strips foldable and nested openers", () => {
+    assert.equal(
+      stripCalloutTitleContinuationsInMarkdown("> [!TIP]- 标题\\"),
+      "> [!TIP]- 标题",
+    )
+    assert.equal(
+      stripCalloutTitleContinuationsInMarkdown("> > [!NOTE] x\\"),
+      "> > [!NOTE] x",
+    )
+  })
+
+  test("does not touch ordinary quotes or mid-title backslashes", () => {
+    assert.equal(
+      stripCalloutTitleContinuationsInMarkdown("> quote\\"),
+      "> quote\\",
+    )
+    assert.equal(
+      stripCalloutTitleContinuationsInMarkdown("> [!NOTE] C:\\Windows"),
+      "> [!NOTE] C:\\Windows",
+    )
+  })
+
+  test("empty title leftover slash becomes default-title case", () => {
+    assert.equal(stripCalloutTitleContinuationsInMarkdown("> [!INFO]\\"), "> [!INFO]")
+  })
+})

--- a/quartz/util/calloutTitle.ts
+++ b/quartz/util/calloutTitle.ts
@@ -1,0 +1,23 @@
+export function stripCalloutTitleContinuation(title: string): string {
+  if (!/(?:\\[ \t]*)+$/.test(title)) {
+    return title
+  }
+  return title.replace(/(?:\\[ \t]*)+$/u, "").replace(/[ \t]+$/u, "")
+}
+
+const CALLOUT_OPEN = /^((?:>[ \t]*)+\[![\w-]+(?:\|[^\]]+)?\][+-]?)(.*)$/
+
+export function stripCalloutTitleContinuationsInMarkdown(src: string): string {
+  const newline = src.includes("\r\n") ? "\r\n" : src.includes("\r") ? "\r" : "\n"
+  return src
+    .split(/\r?\n/)
+    .map((line) => {
+      const match = line.match(CALLOUT_OPEN)
+      if (!match) {
+        return line
+      }
+      const [, directive, rest] = match
+      return `${directive}${stripCalloutTitleContinuation(rest ?? "")}`
+    })
+    .join(newline)
+}


### PR DESCRIPTION
## Summary
- Obsidian callout titles keep a trailing continuation backslash (e.g. 提示\).
- First-party markdown rewrite in createFileParser after plugin textTransforms strips trailing \ from [!TYPE] opener lines only. Body lines and vault notes are unchanged.

Why not vault edits: the trailing \ is valid Obsidian title continuation; publishing should strip it for all [!TYPE] titles without rewriting 花园导览 / 本库使用指南.

Closes #26

## Verify
- 花园导览 and 本库使用指南 info callout title shows 提示, not 提示\
- Callout body unchanged
- npx tsx --test quartz/util/calloutTitle.test.ts

UI: 闻测 must screenshot 本库使用指南 and 花园导览 callout titles on a real device and comment on this PR. No screenshot = not done.