### PR TITLE
fix(search): skip no-op empty-state text writes

### DIFF
--- a/quartz/components/scripts/search.test.ts
+++ b/quartz/components/scripts/search.test.ts
@@ -249,4 +249,56 @@ describe("search empty state i18n", () => {
     assert.equal(emptyHint.textContent, "换个关键词试试？")
     assert.equal(matchTitle.textContent, "Obsidian Flight School")
   })
+
+  test("writes localized empty-state copy only when the text changed", () => {
+    // Given
+    let titleWrites = 0
+    let hintWrites = 0
+    const emptyTitle = {
+      current: "No results.",
+      get textContent() {
+        return this.current
+      },
+      set textContent(value: string) {
+        titleWrites += 1
+        this.current = value
+      },
+    }
+    const emptyHint = {
+      current: "Try another search term?",
+      get textContent() {
+        return this.current
+      },
+      set textContent(value: string) {
+        hintWrites += 1
+        this.current = value
+      },
+    }
+    const labels = {
+      noResults: "没有找到相关笔记",
+      noResultsHint: "换个关键词试试？",
+    }
+    const root = {
+      querySelectorAll(selector: string) {
+        assert.equal(selector, ".result-card.no-match")
+        return [
+          {
+            querySelector(sel: string) {
+              return sel === "h3" ? emptyTitle : emptyHint
+            },
+          },
+        ]
+      },
+    }
+
+    // When
+    applySearchEmptyState(root, labels)
+    applySearchEmptyState(root, labels)
+
+    // Then
+    assert.equal(titleWrites, 1)
+    assert.equal(hintWrites, 1)
+    assert.equal(emptyTitle.textContent, "没有找到相关笔记")
+    assert.equal(emptyHint.textContent, "换个关键词试试？")
+  })
 })

--- a/quartz/components/scripts/searchEmptyState.ts
+++ b/quartz/components/scripts/searchEmptyState.ts
@@ -25,8 +25,12 @@ export function applySearchEmptyState(root: EmptyStateRoot, labels: SearchEmptyS
     if (!card) continue
     const title = card.querySelector("h3")
     const hint = card.querySelector("p")
-    if (title) title.textContent = labels.noResults
-    if (hint) hint.textContent = labels.noResultsHint
+    if (title && title.textContent !== labels.noResults) {
+      title.textContent = labels.noResults
+    }
+    if (hint && hint.textContent !== labels.noResultsHint) {
+      hint.textContent = labels.noResultsHint
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- PR#30 的空态 observer 无条件写 `textContent`，subtree 观察自己，无匹配后主线程 livelock。
- `applySearchEmptyState` 只在文案变化时写一次。不改 #25 文案，不混 #26。

Closes #33

## Base
`fix/search-empty-zh-cn`（PR#30）。diff 只有 observer 护栏。先合 #30，再合这张（或 #30 合进 `v5` 后把本 PR 改 target `v5`）。

## Verify
- 无匹配：标题 `没有找到相关笔记`，提示 `换个关键词试试？`，无 `No results.`
- 随后搜 `obsidian` 仍出卡片，页面不卡死
- `npx tsx --test quartz/components/scripts/search.test.ts` 27 pass

UI：修完交闻测重核 #25。