### PR TITLE
feat(reader): copy tables as Markdown

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -227,6 +227,14 @@ Layout rules:
 - **Accessibility**: Only genuinely overflowing containers enter the tab order. Each receives a localized accessible name and supports native keyboard scrolling; the existing 2px focus ring identifies the active region.
 - **Motion**: Edge cues use the 150ms micro transition and existing Quartz tokens. Reduced-motion removes the transition, and print removes both cues and focus decoration.
 
+### TableMarkdown
+
+- **Structure**: Every authored Markdown table with a header and body receives one 40px copy icon immediately after its scroll container. Transcluded and structurally unsupported tables remain untouched.
+- **Output**: Copy a portable Markdown table with normalized whitespace, escaped pipes and backslashes, and padded short rows. No source content, storage, analytics, dependencies, or network requests are involved.
+- **States**: Ready, copying, copied, failed, hover, pressed, focus-visible, and disabled. Success swaps the copy glyph for a check for 1.8 seconds; failure keeps the action available for retry.
+- **Accessibility**: The native button and polite live region use page-localized names. Keyboard activation, a stable 40px target, print hiding, and Quartz SPA `nav`/`render` cleanup are required.
+- **Motion**: Existing 150ms micro transitions cover hover and press feedback. Reduced-motion removes transitions and spatial press feedback.
+
 ## 6. Motion & Interaction
 
 Motion is quiet utility feedback, not brand theater.

--- a/quartz/components/renderPage.tsx
+++ b/quartz/components/renderPage.tsx
@@ -388,6 +388,8 @@ export function renderPage(
   const fallbackWideContentScroll = TRANSLATIONS[defaultTranslation].components.wideContentScroll
   const wideContentScroll =
     i18n(pageLocale).components.wideContentScroll ?? fallbackWideContentScroll
+  const fallbackTableMarkdown = TRANSLATIONS[defaultTranslation].components.tableMarkdown
+  const tableMarkdown = i18n(pageLocale).components.tableMarkdown ?? fallbackTableMarkdown
   // During local dev (--serve), the dev server serves from root without the
   // baseUrl subpath, so basePath must be empty to avoid broken links.
   const basePath =
@@ -436,6 +438,9 @@ export function renderPage(
         data-search-results-shown={searchResultsShown}
         data-wide-content-table={wideContentScroll.table}
         data-wide-content-code={wideContentScroll.code}
+        data-table-markdown-title={tableMarkdown.title}
+        data-table-markdown-copied={tableMarkdown.copied}
+        data-table-markdown-failed={tableMarkdown.failed}
       >
         {frame.css && <style dangerouslySetInnerHTML={{ __html: frame.css }} />}
         <div id="quartz-root" class="page" data-frame={frame.name}>

--- a/quartz/components/scripts/tableMarkdown.test.ts
+++ b/quartz/components/scripts/tableMarkdown.test.ts
@@ -1,0 +1,65 @@
+import assert from "node:assert"
+import { readFile } from "node:fs/promises"
+import test, { describe } from "node:test"
+import enUs from "../../i18n/locales/en-US"
+import zhCn from "../../i18n/locales/zh-CN"
+import zhTw from "../../i18n/locales/zh-TW"
+import {
+  normalizeMarkdownTableCell,
+  tableMarkdownScript,
+  tableRowsToMarkdown,
+} from "./tableMarkdown"
+
+describe("table Markdown", () => {
+  test("normalizes whitespace and escapes Markdown table delimiters", () => {
+    assert.equal(normalizeMarkdownTableCell("  Quartz\n  |  Obsidian "), "Quartz \\| Obsidian")
+    assert.equal(normalizeMarkdownTableCell("C:\\\\notes"), "C:\\\\\\\\notes")
+    assert.equal(normalizeMarkdownTableCell("中文\u00a0 表格"), "中文 表格")
+  })
+
+  test("builds a portable table and pads short rows", () => {
+    assert.equal(
+      tableRowsToMarkdown([
+        ["Tool", "Use", "Owner"],
+        ["Quartz", "Publish notes"],
+        ["Obsidian", "Write | link", "oldwinter"],
+      ]),
+      [
+        "| Tool | Use | Owner |",
+        "| --- | --- | --- |",
+        "| Quartz | Publish notes |  |",
+        "| Obsidian | Write \\| link | oldwinter |",
+      ].join("\n"),
+    )
+  })
+
+  test("uses the widest row without mutating the input", () => {
+    const rows = [["A"], ["1", "2"]] as const
+
+    assert.equal(tableRowsToMarkdown(rows), "| A |  |\n| --- | --- |\n| 1 | 2 |")
+    assert.deepEqual(rows, [["A"], ["1", "2"]])
+  })
+
+  test("rejects incomplete tables", () => {
+    assert.equal(tableRowsToMarkdown([]), undefined)
+    assert.equal(tableRowsToMarkdown([["Heading"]]), undefined)
+    assert.equal(tableRowsToMarkdown([[], []]), undefined)
+  })
+
+  test("registers localized, idempotent Quartz lifecycle behavior", async () => {
+    const source = await readFile(new URL("./tableMarkdown.ts", import.meta.url), "utf8")
+
+    assert.match(source, /document\.addEventListener\("nav", initializeTableMarkdown\)/)
+    assert.match(source, /document\.addEventListener\("render", initializeTableMarkdown\)/)
+    assert.match(source, /window\.addCleanup\(cleanupTableMarkdown\)/)
+    assert.match(source, /navigator\.clipboard\.writeText\(markdown\)/)
+    assert.match(source, /blockquote\.transclude/)
+    assert.doesNotMatch(tableMarkdownScript, /__name/)
+  })
+
+  test("uses the central English and Chinese locale catalog", () => {
+    assert.equal(enUs.components.tableMarkdown?.title, "Copy table as Markdown")
+    assert.equal(zhCn.components.tableMarkdown?.copied, "表格 Markdown 已复制")
+    assert.equal(zhTw.components.tableMarkdown?.failed, "瀏覽器未能複製表格")
+  })
+})

--- a/quartz/components/scripts/tableMarkdown.ts
+++ b/quartz/components/scripts/tableMarkdown.ts
@@ -1,0 +1,184 @@
+export type TableMarkdownLabels = Readonly<{
+  title: string
+  copied: string
+  failed: string
+}>
+
+export function normalizeMarkdownTableCell(value: string): string {
+  return value.replace(/\s+/gu, " ").trim().replace(/\\/gu, "\\\\").replace(/\|/gu, "\\|")
+}
+
+export function tableRowsToMarkdown(
+  rows: ReadonlyArray<ReadonlyArray<string>>,
+): string | undefined {
+  if (rows.length < 2) return
+  let columnCount = 0
+  for (const row of rows) columnCount = Math.max(columnCount, row.length)
+  if (columnCount === 0) return
+
+  const lines: string[] = []
+  for (let rowIndex = 0; rowIndex < rows.length; rowIndex++) {
+    const row = rows[rowIndex]!
+    const cells: string[] = []
+    for (let columnIndex = 0; columnIndex < columnCount; columnIndex++) {
+      cells.push(normalizeMarkdownTableCell(row[columnIndex] ?? ""))
+    }
+    lines.push(`| ${cells.join(" | ")} |`)
+    if (rowIndex === 0) {
+      lines.push(`| ${new Array<string>(columnCount).fill("---").join(" | ")} |`)
+    }
+  }
+
+  return lines.join("\n")
+}
+
+export function tableElementToMarkdown(table: HTMLTableElement): string | undefined {
+  const firstRow = table.rows.item(0)
+  if (
+    table.rows.length < 2 ||
+    firstRow === null ||
+    !Array.from(firstRow.cells).some((cell) => cell.tagName === "TH")
+  ) {
+    return
+  }
+
+  const rows: string[][] = []
+  for (const row of Array.from(table.rows)) {
+    const values: string[] = []
+    for (const cell of Array.from(row.cells)) {
+      if (cell.rowSpan > 1) return
+      values.push(cell.textContent ?? "")
+      for (let index = 1; index < cell.colSpan; index++) values.push("")
+    }
+    rows.push(values)
+  }
+
+  return tableRowsToMarkdown(rows)
+}
+
+export function tableMarkdownLabels(dataset: DOMStringMap): TableMarkdownLabels | undefined {
+  const {
+    tableMarkdownTitle: title,
+    tableMarkdownCopied: copied,
+    tableMarkdownFailed: failed,
+  } = dataset
+  if (!title || !copied || !failed) return
+
+  return { title, copied, failed }
+}
+
+export const tableMarkdownScript = `
+const normalizeMarkdownTableCell = ${normalizeMarkdownTableCell.toString()}
+const tableRowsToMarkdown = ${tableRowsToMarkdown.toString()}
+const tableElementToMarkdown = ${tableElementToMarkdown.toString()}
+const tableMarkdownLabels = ${tableMarkdownLabels.toString()}
+
+function createTableMarkdownIcon(kind) {
+  const namespace = "http://www.w3.org/2000/svg"
+  const icon = document.createElementNS(namespace, "svg")
+  icon.classList.add("table-markdown-icon", \`table-markdown-icon-\${kind}\`)
+  icon.setAttribute("viewBox", "0 0 24 24")
+  icon.setAttribute("aria-hidden", "true")
+
+  if (kind === "copied") {
+    const path = document.createElementNS(namespace, "path")
+    path.setAttribute("d", "m5 12 4 4L19 6")
+    icon.append(path)
+    return icon
+  }
+
+  const rect = document.createElementNS(namespace, "rect")
+  rect.setAttribute("x", "9")
+  rect.setAttribute("y", "9")
+  rect.setAttribute("width", "12")
+  rect.setAttribute("height", "12")
+  rect.setAttribute("rx", "2")
+  const path = document.createElementNS(namespace, "path")
+  path.setAttribute("d", "M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1")
+  icon.append(rect, path)
+  return icon
+}
+
+let cleanupCurrentTableMarkdown = () => {}
+const cleanupTableMarkdown = () => {
+  const cleanup = cleanupCurrentTableMarkdown
+  cleanupCurrentTableMarkdown = () => {}
+  cleanup()
+}
+
+function initializeTableMarkdown() {
+  cleanupTableMarkdown()
+  const labels = tableMarkdownLabels(document.body.dataset)
+  if (labels === undefined) return
+
+  const cleanups = []
+  const tables = document.querySelectorAll("article .table-container > table")
+  for (const table of tables) {
+    if (!(table instanceof HTMLTableElement) || table.closest("blockquote.transclude")) continue
+    const markdown = tableElementToMarkdown(table)
+    const container = table.parentElement
+    if (markdown === undefined || container === null) continue
+
+    const action = document.createElement("div")
+    action.className = "table-markdown-action"
+    const button = document.createElement("button")
+    button.type = "button"
+    button.className = "table-markdown-button"
+    button.title = labels.title
+    button.setAttribute("aria-label", labels.title)
+    button.dataset.state = "ready"
+    button.append(createTableMarkdownIcon("copy"), createTableMarkdownIcon("copied"))
+    const status = document.createElement("span")
+    status.className = "sr-only"
+    status.setAttribute("aria-live", "polite")
+    action.append(button, status)
+    container.insertAdjacentElement("afterend", action)
+
+    let active = true
+    let resetTimer
+    const setState = (state) => {
+      if (!active) return
+      if (resetTimer !== undefined) window.clearTimeout(resetTimer)
+      button.dataset.state = state
+      const label = state === "copied" ? labels.copied : state === "failed" ? labels.failed : labels.title
+      button.title = label
+      button.setAttribute("aria-label", label)
+      status.textContent = state === "ready" ? "" : label
+      if (state !== "ready") {
+        resetTimer = window.setTimeout(() => setState("ready"), 1800)
+      }
+    }
+    const copyTable = async () => {
+      if (!navigator.clipboard) {
+        setState("failed")
+        return
+      }
+      button.disabled = true
+      try {
+        await navigator.clipboard.writeText(markdown)
+        setState("copied")
+      } catch {
+        setState("failed")
+      } finally {
+        if (active) button.disabled = false
+      }
+    }
+    button.addEventListener("click", copyTable)
+    cleanups.push(() => {
+      active = false
+      if (resetTimer !== undefined) window.clearTimeout(resetTimer)
+      button.removeEventListener("click", copyTable)
+      action.remove()
+    })
+  }
+
+  if (cleanups.length === 0) return
+  cleanupCurrentTableMarkdown = () => {
+    for (const cleanup of cleanups) cleanup()
+  }
+  window.addCleanup(cleanupTableMarkdown)
+}
+
+document.addEventListener("nav", initializeTableMarkdown)
+document.addEventListener("render", initializeTableMarkdown)
+`

--- a/quartz/components/styles/tableMarkdown.scss
+++ b/quartz/components/styles/tableMarkdown.scss
@@ -1,0 +1,87 @@
+.table-markdown-action {
+  display: flex;
+  width: 100%;
+  min-height: 2.5rem;
+  margin-block: 0.25rem 0.75rem;
+  justify-content: flex-end;
+}
+
+.table-markdown-button {
+  appearance: none;
+  display: grid;
+  box-sizing: border-box;
+  width: 2.5rem;
+  height: 2.5rem;
+  padding: 0;
+  place-items: center;
+  border: 1px solid color-mix(in srgb, var(--gray) 54%, transparent);
+  border-radius: 6px;
+  background-color: var(--light);
+  color: var(--dark);
+  cursor: pointer;
+  touch-action: manipulation;
+  transition:
+    background-color 0.15s ease-out,
+    color 0.15s ease-out,
+    transform 0.15s ease-out;
+
+  &:hover {
+    border-color: var(--secondary);
+    background-color: var(--lightgray);
+    color: var(--secondary);
+  }
+
+  &:active {
+    transform: scale(0.96);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--secondary);
+    outline-offset: 2px;
+  }
+
+  &:disabled {
+    cursor: wait;
+    opacity: 0.72;
+  }
+
+  &[data-state="copied"] {
+    color: var(--secondary);
+  }
+}
+
+.table-markdown-icon {
+  grid-area: 1 / 1;
+  width: 1.125rem;
+  height: 1.125rem;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 2;
+}
+
+.table-markdown-icon-copied,
+.table-markdown-button[data-state="copied"] .table-markdown-icon-copy {
+  display: none;
+}
+
+.table-markdown-button[data-state="copied"] .table-markdown-icon-copied {
+  display: block;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .table-markdown-button {
+    transition: none;
+
+    &:active {
+      transform: none;
+    }
+  }
+}
+
+@media print {
+  .table-markdown-action {
+    display: none;
+  }
+}

--- a/quartz/i18n/locales/definition.ts
+++ b/quartz/i18n/locales/definition.ts
@@ -93,6 +93,11 @@ export interface Translation {
       table: string
       code: string
     }
+    tableMarkdown?: {
+      title: string
+      copied: string
+      failed: string
+    }
     explorer: {
       title: string
     }

--- a/quartz/i18n/locales/en-US.ts
+++ b/quartz/i18n/locales/en-US.ts
@@ -90,6 +90,11 @@ export default {
       table: "Scrollable table",
       code: "Scrollable code block",
     },
+    tableMarkdown: {
+      title: "Copy table as Markdown",
+      copied: "Table Markdown copied",
+      failed: "The browser could not copy this table",
+    },
     explorer: {
       title: "Explorer",
     },

--- a/quartz/i18n/locales/zh-CN.ts
+++ b/quartz/i18n/locales/zh-CN.ts
@@ -90,6 +90,11 @@ export default {
       table: "可横向滚动的表格",
       code: "可横向滚动的代码块",
     },
+    tableMarkdown: {
+      title: "复制表格为 Markdown",
+      copied: "表格 Markdown 已复制",
+      failed: "浏览器未能复制表格",
+    },
     explorer: {
       title: "探索",
     },

--- a/quartz/i18n/locales/zh-TW.ts
+++ b/quartz/i18n/locales/zh-TW.ts
@@ -87,6 +87,11 @@ export default {
       table: "可橫向捲動的表格",
       code: "可橫向捲動的程式碼區塊",
     },
+    tableMarkdown: {
+      title: "複製表格為 Markdown",
+      copied: "表格 Markdown 已複製",
+      failed: "瀏覽器未能複製表格",
+    },
     explorer: {
       title: "探索",
     },

--- a/quartz/plugins/emitters/componentResources.test.ts
+++ b/quartz/plugins/emitters/componentResources.test.ts
@@ -197,4 +197,22 @@ describe("componentResources", () => {
       assert.ok(styleIndex < spaBranchIndex)
     })
   })
+
+  test("includes table Markdown copying when SPA navigation is disabled", () => {
+    const emitterPath = new URL("./componentResources.ts", import.meta.url)
+    const source = readFile(emitterPath, "utf8")
+
+    return source.then((contents) => {
+      const scriptIndex = contents.indexOf(
+        "componentResources.afterDOMLoaded.push(tableMarkdownScript)",
+      )
+      const styleIndex = contents.indexOf("componentResources.css.push(tableMarkdownStyle)")
+      const spaBranchIndex = contents.indexOf("if (cfg.enableSPA)")
+
+      assert.notEqual(scriptIndex, -1)
+      assert.notEqual(styleIndex, -1)
+      assert.ok(scriptIndex < spaBranchIndex)
+      assert.ok(styleIndex < spaBranchIndex)
+    })
+  })
 })

--- a/quartz/plugins/emitters/componentResources.ts
+++ b/quartz/plugins/emitters/componentResources.ts
@@ -30,6 +30,8 @@ import { wideContentScrollScript } from "../../components/scripts/wideContentScr
 import { searchEmptyStateScript } from "../../components/scripts/searchEmptyState"
 import searchFeedbackStyle from "../../components/styles/searchFeedback.scss"
 import wideContentScrollStyle from "../../components/styles/wideContentScroll.scss"
+import { tableMarkdownScript } from "../../components/scripts/tableMarkdown"
+import tableMarkdownStyle from "../../components/styles/tableMarkdown.scss"
 import { BuildCtx } from "../../util/ctx"
 import { QuartzComponent } from "../../components/types"
 import { normalizeResource } from "../../util/resources"
@@ -126,6 +128,8 @@ function addGlobalPageResources(ctx: BuildCtx, componentResources: ComponentReso
   componentResources.afterDOMLoaded.push(searchEmptyStateScript)
   componentResources.css.push(searchFeedbackStyle)
   componentResources.css.push(wideContentScrollStyle)
+  componentResources.afterDOMLoaded.push(tableMarkdownScript)
+  componentResources.css.push(tableMarkdownStyle)
 
   // popovers
   if (cfg.enablePopovers) {


### PR DESCRIPTION
这次为正文中的 Markdown 表格构建了一个本地化的一键复制按钮：读者可以把网页表格直接带回 Obsidian、Markdown 编辑器或 issue，而不必手动选中和重排列。它只在结构可安全转换的原生表格上出现，输出会归一化空白、转义竖线与反斜杠并补齐短行；我觉得它值得合并，因为它把一个高频但繁琐的复用动作变成了清晰、可撤销、完全本地的 40px 操作，同时不改变任何原始内容。

## Validation

- `npx tsx --test quartz/components/scripts/tableMarkdown.test.ts quartz/plugins/emitters/componentResources.test.ts` - 14/14 passed
- `npx tsc --noEmit` - passed
- scoped Prettier check - passed
- `git diff --check` - passed
- `npx quartz build` - passed (314 Markdown inputs, 1,913 emitted files)
- `npm test` - 247/248 passed; the sole failure is the known baseline `jsdom` package absence in `local-plugins/theme-switcher/test/themeSwitcherScript.test.ts`
- Real Chromium QA passed on desktop and mobile for keyboard copy, success/failure/retry feedback, focus retention, dark theme, reduced motion, no page overflow, and idempotent SPA navigation/render lifecycle

## Impact

- Adds a removable reader enhancement for supported authored tables only.
- Excludes transcluded and structurally unsupported tables.
- Adds English, Simplified Chinese, and Traditional Chinese labels with the existing English fallback pattern.
- No dependency, lockfile, content, storage, analytics, network, configuration, CI, or deployment changes.

## Rollback

Revert this commit. The feature writes no persistent state and requires no data or content cleanup.

## Hosted status

Netlify deploy preview `6a95e87254d01300081b844d` failed all four contexts. GitHub exposed zero annotations and Netlify's public API returned an unavailable summary with no messages, publish time, or deploy time. The exact-SHA local build and browser QA above pass; no deployment, authentication, configuration, or infrastructure change was made to bypass this opaque hosted-preview blocker.
