### PR TITLE
feat(search): show localized result counts

### DIFF
--- a/quartz/components/renderPage.tsx
+++ b/quartz/components/renderPage.tsx
@@ -378,6 +378,11 @@ export function renderPage(
   const searchNoResults = searchI18n.noResults ?? fallbackSearch.noResults ?? "No results."
   const searchNoResultsHint =
     searchI18n.noResultsHint ?? fallbackSearch.noResultsHint ?? "Try another search term?"
+  const searchResultList = searchI18n.resultList ?? fallbackSearch.resultList ?? "Search results"
+  const searchResultShown =
+    searchI18n.resultShown ?? fallbackSearch.resultShown ?? "Showing {count} result"
+  const searchResultsShown =
+    searchI18n.resultsShown ?? fallbackSearch.resultsShown ?? "Showing {count} results"
   const fallbackWideContentScroll = TRANSLATIONS[defaultTranslation].components.wideContentScroll
   const wideContentScroll =
     i18n(pageLocale).components.wideContentScroll ?? fallbackWideContentScroll
@@ -420,6 +425,9 @@ export function renderPage(
         data-note-share-failed={noteShare.failed}
         data-search-no-results={searchNoResults}
         data-search-no-results-hint={searchNoResultsHint}
+        data-search-result-list={searchResultList}
+        data-search-result-shown={searchResultShown}
+        data-search-results-shown={searchResultsShown}
         data-wide-content-table={wideContentScroll.table}
         data-wide-content-code={wideContentScroll.code}
       >

--- a/quartz/components/scripts/search.test.ts
+++ b/quartz/components/scripts/search.test.ts
@@ -1,6 +1,13 @@
 import test, { describe } from "node:test"
 import { i18n } from "../../i18n"
-import { applySearchEmptyState, searchEmptyStateLabels } from "./searchEmptyState"
+import {
+  applySearchEmptyState,
+  ensureSearchResultStatus,
+  searchEmptyStateLabels,
+  searchEmptyStateScript,
+  searchResultSummary,
+  updateSearchResultFeedback,
+} from "./searchEmptyState"
 import assert from "node:assert"
 
 // Inline the encoder function from search.inline.ts for testing
@@ -175,6 +182,9 @@ describe("search empty state i18n", () => {
     // Then
     assert.equal(search.noResults, "没有找到相关笔记")
     assert.equal(search.noResultsHint, "换个关键词试试？")
+    assert.equal(search.resultList, "搜索结果")
+    assert.equal(search.resultShown, "显示 {count} 条结果")
+    assert.equal(search.resultsShown, "显示 {count} 条结果")
   })
 
   test("en-US keeps the English empty-state copy", () => {
@@ -187,6 +197,9 @@ describe("search empty state i18n", () => {
     // Then
     assert.equal(search.noResults, "No results.")
     assert.equal(search.noResultsHint, "Try another search term?")
+    assert.equal(search.resultList, "Search results")
+    assert.equal(search.resultShown, "Showing {count} result")
+    assert.equal(search.resultsShown, "Showing {count} results")
   })
 
   test("zh-TW preserves the existing fallback empty state", () => {
@@ -199,6 +212,9 @@ describe("search empty state i18n", () => {
     // Then
     assert.equal(search.noResults, undefined)
     assert.equal(search.noResultsHint, undefined)
+    assert.equal(search.resultList, "搜尋結果")
+    assert.equal(search.resultShown, "顯示 {count} 筆結果")
+    assert.equal(search.resultsShown, "顯示 {count} 筆結果")
   })
 
   test("reads labels rendered by Quartz i18n", () => {
@@ -206,6 +222,9 @@ describe("search empty state i18n", () => {
     const dataset = {
       searchNoResults: "没有找到相关笔记",
       searchNoResultsHint: "换个关键词试试？",
+      searchResultList: "搜索结果",
+      searchResultShown: "显示 {count} 条结果",
+      searchResultsShown: "显示 {count} 条结果",
     } as DOMStringMap
 
     // When
@@ -215,6 +234,9 @@ describe("search empty state i18n", () => {
     assert.deepEqual(labels, {
       noResults: "没有找到相关笔记",
       noResultsHint: "换个关键词试试？",
+      resultList: "搜索结果",
+      resultShown: "显示 {count} 条结果",
+      resultsShown: "显示 {count} 条结果",
     })
   })
 
@@ -239,6 +261,9 @@ describe("search empty state i18n", () => {
     const labels = {
       noResults: "没有找到相关笔记",
       noResultsHint: "换个关键词试试？",
+      resultList: "搜索结果",
+      resultShown: "显示 {count} 条结果",
+      resultsShown: "显示 {count} 条结果",
     }
     const root = {
       querySelectorAll(selector: string) {
@@ -289,6 +314,9 @@ describe("search empty state i18n", () => {
     const labels = {
       noResults: "没有找到相关笔记",
       noResultsHint: "换个关键词试试？",
+      resultList: "搜索结果",
+      resultShown: "显示 {count} 条结果",
+      resultsShown: "显示 {count} 条结果",
     }
     const root = {
       querySelectorAll(selector: string) {
@@ -312,5 +340,181 @@ describe("search empty state i18n", () => {
     assert.equal(hintWrites, 1)
     assert.equal(emptyTitle.textContent, "没有找到相关笔记")
     assert.equal(emptyHint.textContent, "换个关键词试试？")
+  })
+})
+
+describe("search result feedback", () => {
+  const labels = {
+    noResults: "没有找到相关笔记",
+    noResultsHint: "换个关键词试试？",
+    resultList: "搜索结果",
+    resultShown: "显示 {count} 条结果",
+    resultsShown: "显示 {count} 条结果",
+  }
+
+  const createAttributeNode = (initial: Record<string, string> = {}) => {
+    const attributes = new Map(Object.entries(initial))
+    let currentText = ""
+    let attributeWrites = 0
+    let textWrites = 0
+
+    return {
+      get textContent() {
+        return currentText
+      },
+      set textContent(value: string | null) {
+        textWrites += 1
+        currentText = value ?? ""
+      },
+      getAttribute(name: string) {
+        return attributes.get(name) ?? null
+      },
+      setAttribute(name: string, value: string) {
+        attributeWrites += 1
+        attributes.set(name, value)
+      },
+      removeAttribute(name: string) {
+        attributeWrites += 1
+        attributes.delete(name)
+      },
+      get attributeWrites() {
+        return attributeWrites
+      },
+      get textWrites() {
+        return textWrites
+      },
+    }
+  }
+
+  const createResults = (count: number, initial: Record<string, string> = {}) => {
+    const results = createAttributeNode(initial)
+    return Object.assign(results, {
+      querySelectorAll(selector: string) {
+        assert.equal(selector, ".result-card:not(.no-match)")
+        return Array.from({ length: count }, () => ({}))
+      },
+    })
+  }
+
+  test("formats bounded rendered counts without evaluating the locale template", () => {
+    assert.equal(searchResultSummary("Showing {count} of {count}", 8.9), "Showing 8 of 8")
+    assert.equal(searchResultSummary("显示 {count} 条结果", Number.NaN), "显示 0 条结果")
+    assert.equal(searchResultSummary("显示 {count} 条结果", -2), "显示 0 条结果")
+  })
+
+  test("shows and announces the number of rendered result cards", () => {
+    const results = createResults(8)
+    const status = createAttributeNode()
+
+    updateSearchResultFeedback(results, status, labels, true)
+
+    assert.equal(results.getAttribute("data-search-result-summary"), "显示 8 条结果")
+    assert.equal(results.getAttribute("aria-label"), "显示 8 条结果")
+    assert.equal(status.textContent, "显示 8 条结果")
+  })
+
+  test("uses the singular template for one rendered result", () => {
+    const results = createResults(1)
+    const status = createAttributeNode()
+    const englishLabels = {
+      noResults: "No results.",
+      noResultsHint: "Try another search term?",
+      resultList: "Search results",
+      resultShown: "Showing {count} result",
+      resultsShown: "Showing {count} results",
+    }
+
+    updateSearchResultFeedback(results, status, englishLabels, true)
+
+    assert.equal(results.getAttribute("data-search-result-summary"), "Showing 1 result")
+    assert.equal(results.getAttribute("aria-label"), "Showing 1 result")
+    assert.equal(status.textContent, "Showing 1 result")
+  })
+
+  test("announces no matches without adding a duplicate visible count", () => {
+    const results = createResults(0, {
+      "aria-label": "显示 3 条结果",
+      "data-search-result-summary": "显示 3 条结果",
+    })
+    const status = createAttributeNode()
+
+    updateSearchResultFeedback(results, status, labels, true)
+
+    assert.equal(results.getAttribute("data-search-result-summary"), null)
+    assert.equal(results.getAttribute("aria-label"), "没有找到相关笔记")
+    assert.equal(status.textContent, "没有找到相关笔记")
+  })
+
+  test("clears stale feedback and restores the localized list label", () => {
+    const results = createResults(0, {
+      "aria-label": "显示 1 条结果",
+      "data-search-result-summary": "显示 1 条结果",
+    })
+    const status = createAttributeNode()
+    status.textContent = "显示 1 条结果"
+
+    updateSearchResultFeedback(results, status, labels, false)
+
+    assert.equal(results.getAttribute("data-search-result-summary"), null)
+    assert.equal(results.getAttribute("aria-label"), "搜索结果")
+    assert.equal(status.textContent, "")
+  })
+
+  test("skips unchanged attribute and live-region writes", () => {
+    const results = createResults(1, {
+      "aria-label": "显示 1 条结果",
+      "data-search-result-summary": "显示 1 条结果",
+    })
+    const status = createAttributeNode()
+    status.textContent = "显示 1 条结果"
+    const attributeWrites = results.attributeWrites
+    const textWrites = status.textWrites
+
+    updateSearchResultFeedback(results, status, labels, true)
+    updateSearchResultFeedback(results, status, labels, true)
+
+    assert.equal(results.attributeWrites, attributeWrites)
+    assert.equal(status.textWrites, textWrites)
+  })
+
+  test("creates one polite live region outside the results list", () => {
+    let status: ReturnType<typeof createAttributeNode> | null = null
+    let created = 0
+    const search = {
+      querySelector(selector: string) {
+        assert.equal(selector, ".search-result-status")
+        return status
+      },
+      appendChild(node: ReturnType<typeof createAttributeNode>) {
+        status = node
+      },
+      ownerDocument: {
+        createElement(tagName: string) {
+          assert.equal(tagName, "p")
+          created += 1
+          return createAttributeNode()
+        },
+      },
+    }
+
+    const first = ensureSearchResultStatus(search)
+    const second = ensureSearchResultStatus(search)
+
+    assert.strictEqual(first, second)
+    assert.equal(created, 1)
+    assert.equal(first.getAttribute("class"), "search-result-status")
+    assert.equal(first.getAttribute("role"), "status")
+    assert.equal(first.getAttribute("aria-live"), "polite")
+    assert.equal(first.getAttribute("aria-atomic"), "true")
+  })
+
+  test("binds both Quartz render events and registers observer cleanup", () => {
+    assert.match(searchEmptyStateScript, /document\.addEventListener\("nav", bindSearchFeedback\)/)
+    assert.match(
+      searchEmptyStateScript,
+      /document\.addEventListener\("render", bindSearchFeedback\)/,
+    )
+    assert.match(searchEmptyStateScript, /window\.addCleanup\(cleanupSearchFeedback\)/)
+    assert.match(searchEmptyStateScript, /searchFeedbackObserver\?\.disconnect\(\)/)
   })
 })

--- a/quartz/components/scripts/searchEmptyState.ts
+++ b/quartz/components/scripts/searchEmptyState.ts
@@ -1,13 +1,22 @@
 export type SearchEmptyStateLabels = Readonly<{
   noResults: string
   noResultsHint: string
+  resultList: string
+  resultShown: string
+  resultsShown: string
 }>
 
 export function searchEmptyStateLabels(dataset: DOMStringMap): SearchEmptyStateLabels | undefined {
-  const { searchNoResults: noResults, searchNoResultsHint: noResultsHint } = dataset
-  if (!noResults || !noResultsHint) return
+  const {
+    searchNoResults: noResults,
+    searchNoResultsHint: noResultsHint,
+    searchResultList: resultList,
+    searchResultShown: resultShown,
+    searchResultsShown: resultsShown,
+  } = dataset
+  if (!noResults || !noResultsHint || !resultList || !resultShown || !resultsShown) return
 
-  return { noResults, noResultsHint }
+  return { noResults, noResultsHint, resultList, resultShown, resultsShown }
 }
 
 type EmptyStateNode = {
@@ -34,33 +43,119 @@ export function applySearchEmptyState(root: EmptyStateRoot, labels: SearchEmptyS
   }
 }
 
+type AttributeNode = {
+  getAttribute(name: string): string | null
+  setAttribute(name: string, value: string): void
+  removeAttribute(name: string): void
+}
+
+type SearchResultContainer = AttributeNode & {
+  querySelectorAll(selector: string): ArrayLike<unknown>
+}
+
+type SearchStatusNode = AttributeNode & {
+  textContent: string | null
+}
+
+type SearchRoot = {
+  querySelector(selector: string): SearchStatusNode | null
+  appendChild(node: SearchStatusNode): void
+  ownerDocument: {
+    createElement(tagName: string): SearchStatusNode
+  }
+}
+
+export function searchResultSummary(template: string, count: number): string {
+  const safeCount = Number.isFinite(count) ? Math.max(0, Math.trunc(count)) : 0
+  return template.replaceAll("{count}", String(safeCount))
+}
+
+export function ensureSearchResultStatus(search: SearchRoot): SearchStatusNode {
+  const existing = search.querySelector(".search-result-status")
+  if (existing) return existing
+
+  const status = search.ownerDocument.createElement("p")
+  status.setAttribute("class", "search-result-status")
+  status.setAttribute("role", "status")
+  status.setAttribute("aria-live", "polite")
+  status.setAttribute("aria-atomic", "true")
+  search.appendChild(status)
+  return status
+}
+
+export function updateSearchResultFeedback(
+  results: SearchResultContainer,
+  status: SearchStatusNode,
+  labels: SearchEmptyStateLabels,
+  active: boolean,
+): void {
+  const count = results.querySelectorAll(".result-card:not(.no-match)").length
+  const summary =
+    count > 0
+      ? searchResultSummary(count === 1 ? labels.resultShown : labels.resultsShown, count)
+      : undefined
+  const listLabel = !active ? labels.resultList : (summary ?? labels.noResults)
+  const announcement = !active ? "" : (summary ?? labels.noResults)
+
+  if (results.getAttribute("aria-label") !== listLabel) {
+    results.setAttribute("aria-label", listLabel)
+  }
+  if (summary) {
+    if (results.getAttribute("data-search-result-summary") !== summary) {
+      results.setAttribute("data-search-result-summary", summary)
+    }
+  } else if (results.getAttribute("data-search-result-summary") !== null) {
+    results.removeAttribute("data-search-result-summary")
+  }
+  if (status.textContent !== announcement) {
+    status.textContent = announcement
+  }
+}
+
 export const searchEmptyStateScript = `
 const searchEmptyStateLabels = ${searchEmptyStateLabels.toString()}
 const applySearchEmptyState = ${applySearchEmptyState.toString()}
+const searchResultSummary = ${searchResultSummary.toString()}
+const ensureSearchResultStatus = ${ensureSearchResultStatus.toString()}
+const updateSearchResultFeedback = ${updateSearchResultFeedback.toString()}
 
-let searchEmptyStateObserver
+let searchFeedbackObserver
 
-function localizeSearchEmptyState() {
+function cleanupSearchFeedback() {
+  searchFeedbackObserver?.disconnect()
+  searchFeedbackObserver = undefined
+}
+
+function updateSearchFeedback() {
   const labels = searchEmptyStateLabels(document.body.dataset)
   if (!labels) return
   applySearchEmptyState(document, labels)
+
+  for (const results of document.querySelectorAll(".results-container")) {
+    const search = results.closest(".search")
+    const layout = results.closest(".search-layout")
+    if (!search || !layout) continue
+    const status = ensureSearchResultStatus(search)
+    updateSearchResultFeedback(results, status, labels, layout.classList.contains("display-results"))
+  }
 }
 
-function bindSearchEmptyState() {
-  localizeSearchEmptyState()
+function bindSearchFeedback() {
+  cleanupSearchFeedback()
+  updateSearchFeedback()
   if (typeof MutationObserver === "undefined") return
-  if (searchEmptyStateObserver) searchEmptyStateObserver.disconnect()
-  searchEmptyStateObserver = new MutationObserver(() => localizeSearchEmptyState())
+  searchFeedbackObserver = new MutationObserver(() => updateSearchFeedback())
   const targets = document.querySelectorAll(".search-layout, .results-container")
   if (targets.length === 0) {
-    searchEmptyStateObserver.observe(document.body, { childList: true, subtree: true })
-    return
+    searchFeedbackObserver.observe(document.body, { childList: true, subtree: true })
+  } else {
+    for (const target of targets) {
+      searchFeedbackObserver.observe(target, { childList: true, subtree: true })
+    }
   }
-  for (const target of targets) {
-    searchEmptyStateObserver.observe(target, { childList: true, subtree: true })
-  }
+  window.addCleanup(cleanupSearchFeedback)
 }
 
-document.addEventListener("nav", bindSearchEmptyState)
-document.addEventListener("render", bindSearchEmptyState)
+document.addEventListener("nav", bindSearchFeedback)
+document.addEventListener("render", bindSearchFeedback)
 `

--- a/quartz/components/styles/searchFeedback.scss
+++ b/quartz/components/styles/searchFeedback.scss
@@ -1,0 +1,38 @@
+.search .results-container[data-search-result-summary]::before {
+  content: attr(data-search-result-summary);
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  display: block;
+  box-sizing: border-box;
+  padding: 0.65rem 1rem 0.55rem;
+  border-bottom: 1px solid var(--lightgray);
+  background: var(--light);
+  color: var(--gray);
+  font-family: var(--bodyFont);
+  font-size: 0.85rem;
+  font-variant-numeric: tabular-nums;
+  line-height: 1.2;
+  letter-spacing: 0;
+  pointer-events: none;
+}
+
+.search-result-status {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media print {
+  .search .results-container[data-search-result-summary]::before,
+  .search-result-status {
+    display: none;
+  }
+}

--- a/quartz/i18n/locales/definition.ts
+++ b/quartz/i18n/locales/definition.ts
@@ -109,6 +109,9 @@ export interface Translation {
       searchBarPlaceholder: string
       noResults?: string
       noResultsHint?: string
+      resultList?: string
+      resultShown?: string
+      resultsShown?: string
     }
     tableOfContents: {
       title: string

--- a/quartz/i18n/locales/en-US.ts
+++ b/quartz/i18n/locales/en-US.ts
@@ -106,6 +106,9 @@ export default {
       searchBarPlaceholder: "Search for something",
       noResults: "No results.",
       noResultsHint: "Try another search term?",
+      resultList: "Search results",
+      resultShown: "Showing {count} result",
+      resultsShown: "Showing {count} results",
     },
     tableOfContents: {
       title: "Table of Contents",

--- a/quartz/i18n/locales/zh-CN.ts
+++ b/quartz/i18n/locales/zh-CN.ts
@@ -106,6 +106,9 @@ export default {
       searchBarPlaceholder: "搜索些什么",
       noResults: "没有找到相关笔记",
       noResultsHint: "换个关键词试试？",
+      resultList: "搜索结果",
+      resultShown: "显示 {count} 条结果",
+      resultsShown: "显示 {count} 条结果",
     },
     tableOfContents: {
       title: "目录",

--- a/quartz/i18n/locales/zh-TW.ts
+++ b/quartz/i18n/locales/zh-TW.ts
@@ -101,6 +101,9 @@ export default {
     search: {
       title: "搜尋",
       searchBarPlaceholder: "搜尋些什麼",
+      resultList: "搜尋結果",
+      resultShown: "顯示 {count} 筆結果",
+      resultsShown: "顯示 {count} 筆結果",
     },
     tableOfContents: {
       title: "目錄",

--- a/quartz/plugins/emitters/componentResources.test.ts
+++ b/quartz/plugins/emitters/componentResources.test.ts
@@ -161,4 +161,22 @@ describe("componentResources", () => {
       assert.ok(styleIndex < spaBranchIndex)
     })
   })
+
+  test("includes search feedback when SPA navigation is disabled", () => {
+    const emitterPath = new URL("./componentResources.ts", import.meta.url)
+    const source = readFile(emitterPath, "utf8")
+
+    return source.then((contents) => {
+      const scriptIndex = contents.indexOf(
+        "componentResources.afterDOMLoaded.push(searchEmptyStateScript)",
+      )
+      const styleIndex = contents.indexOf("componentResources.css.push(searchFeedbackStyle)")
+      const spaBranchIndex = contents.indexOf("if (cfg.enableSPA)")
+
+      assert.notEqual(scriptIndex, -1)
+      assert.notEqual(styleIndex, -1)
+      assert.ok(scriptIndex < spaBranchIndex)
+      assert.ok(styleIndex < spaBranchIndex)
+    })
+  })
 })

--- a/quartz/plugins/emitters/componentResources.ts
+++ b/quartz/plugins/emitters/componentResources.ts
@@ -26,6 +26,7 @@ import { noteShareScript } from "../../components/scripts/noteShare"
 import noteShareStyle from "../../components/styles/noteShare.scss"
 import { wideContentScrollScript } from "../../components/scripts/wideContentScroll"
 import { searchEmptyStateScript } from "../../components/scripts/searchEmptyState"
+import searchFeedbackStyle from "../../components/styles/searchFeedback.scss"
 import wideContentScrollStyle from "../../components/styles/wideContentScroll.scss"
 import { BuildCtx } from "../../util/ctx"
 import { QuartzComponent } from "../../components/types"
@@ -119,6 +120,7 @@ function addGlobalPageResources(ctx: BuildCtx, componentResources: ComponentReso
   componentResources.css.push(noteShareStyle)
   componentResources.afterDOMLoaded.push(wideContentScrollScript)
   componentResources.afterDOMLoaded.push(searchEmptyStateScript)
+  componentResources.css.push(searchFeedbackStyle)
   componentResources.css.push(wideContentScrollStyle)
 
   // popovers


### PR DESCRIPTION
## 构建了什么

搜索浮层现在会在结果列表顶部显示当前实际渲染的结果数量，并同步更新结果列表的 `aria-label` 与 polite live region。简体中文、繁体中文和英文均有本地化文案；单数、复数、无结果、清空搜索和 SPA 导航后的状态都会正确复位。

## 为什么值得合并

结果较多时，读者可以立即判断当前看到多少条匹配，不必手动数卡片；屏幕阅读器用户也会获得同一条反馈。实现复用仓库现有的搜索扩展和 Quartz 生命周期，不修改外部插件、依赖、持久化数据或网络行为。

## 验证

- `npx tsx --test quartz/components/scripts/search.test.ts quartz/plugins/emitters/componentResources.test.ts`：44/44 通过
- `npx tsc --noEmit`：通过
- 变更文件 `npx prettier --check ...`：通过
- `git diff HEAD^ --check`：通过
- `npx quartz build`：通过，314 篇输入，1917 个输出
- 浏览器：桌面与 390px 移动端、浅色与深色、简中与英文、1/8/0 条结果、标签搜索、清空搜索、回车跳转及 SPA 返回均已验证；无页面错误或横向溢出
- `npm test`：248/250 通过；其余两项均可在未改动的 `origin/v5` 基线复现：主题切换器测试缺少已声明的 `jsdom` 依赖，以及 `content/AboutTheGarden.md` 的 Quartz Syncer 链接期望不一致

## 影响范围

- 为搜索文案增加 3 个可选 locale 字段，并保留英文回退
- 为现有搜索扩展增加结果计数、无障碍状态和对应样式
- 不改变搜索排序、索引、结果上限或跳转行为

## 回滚

回滚提交 `2c71e734516e95d73b4d1c9455c14770418cf509` 即可；没有数据迁移或配置变更。

## 已知风险

- 计数表示外部 Quartz 搜索插件实际渲染的卡片数，不宣称索引中的总匹配数
- 全量测试的两项既有基线失败仍然存在，但失败签名与本次改动无关
- Netlify deploy preview 的四个上下文均失败；GitHub 没有提供注解，Netlify 公共 API 只返回 `summary.status: unavailable` 且没有消息。本地精确 SHA 生产构建已通过，因此没有修改部署配置或凭据
- 审查了当前开放 issue：#36 与 #43 属于已合并代码尚未部署/内容同步问题，#26 已有 #32 处理；本功能没有可安全关闭的 issue，因此不作强行关联
