### PR TITLE
fix(reader): 清理 bfcache 恢复后的弹出层

### DIFF
--- a/quartz/components/scripts/popover.inline.ts
+++ b/quartz/components/scripts/popover.inline.ts
@@ -139,3 +139,8 @@ function setupPopovers() {
 
 document.addEventListener("nav", setupPopovers)
 document.addEventListener("render", setupPopovers)
+window.addEventListener("pageshow", (event) => {
+  if (event.persisted) {
+    clearActivePopover()
+  }
+})

--- a/quartz/components/scripts/popover.test.ts
+++ b/quartz/components/scripts/popover.test.ts
@@ -1,5 +1,7 @@
 import test, { describe } from "node:test"
 import assert from "node:assert"
+import { readFile } from "node:fs/promises"
+import { fileURLToPath } from "node:url"
 
 type ScrollArg = { top: number; behavior?: ScrollBehavior }
 type FakeHeading = { offsetTop: number }
@@ -182,4 +184,15 @@ describe("buggy showPopover (lexical-capture pattern) regression guard", () => {
 
     assert.doesNotThrow(() => simulateBuggyMouseEnter(""))
   })
+})
+
+test("clears active popovers when a page is restored from bfcache", async () => {
+  const source = await readFile(
+    fileURLToPath(new URL("./popover.inline.ts", import.meta.url)),
+    "utf8",
+  )
+  assert.match(
+    source,
+    /window\.addEventListener\("pageshow", \(event\) => \{\s*if \(event\.persisted\) \{\s*clearActivePopover\(\)\s*\}\s*\}\)/s,
+  )
 })


### PR DESCRIPTION
## What changed

Fixes stale active popovers after a touch device navigates to a non-HTML asset and returns through the browser back-forward cache. A persisted `pageshow` event now reuses the existing popover cleanup path, clearing the active anchor and hiding cached popover content without affecting ordinary page restores.

Closes #2537

## Validation

- `npx tsx --test quartz/components/scripts/popover.test.ts` (7/7)
- `npx tsc --noEmit`
- `npx prettier quartz/components/scripts/popover.inline.ts quartz/components/scripts/popover.test.ts --check`
- `npm_config_engine_strict=false npx quartz build` (314 inputs, 1,922 outputs)
- Browser runtime check with Chromium: `pageshow persisted=false` preserves the active popover; `pageshow persisted=true` removes its active state.

The full suite is 352/354. The two unrelated baseline failures are the missing `jsdom` dependency in `local-plugins/theme-switcher` and the existing homepage canonical-link expectation.

## Impact and rollback

This changes only the popover browser script and its regression test. Reverting `c37c2eaac28cf18aa469c987c84f5b6ecf449361` restores the previous lifecycle behavior.

## Risks

The handler runs only for persisted page restores and delegates to the existing idempotent cleanup function. No navigation, fetch, or popover creation behavior changes.
