### PR TITLE
feat(reader): 复制表格时保留列对齐

### DIFF
--- a/quartz/components/scripts/tableMarkdown.test.ts
+++ b/quartz/components/scripts/tableMarkdown.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert"
 import { readFile } from "node:fs/promises"
 import test, { describe } from "node:test"
+import { runInNewContext } from "node:vm"
 import enUs from "../../i18n/locales/en-US"
 import zhCn from "../../i18n/locales/zh-CN"
 import zhTw from "../../i18n/locales/zh-TW"
@@ -38,6 +39,59 @@ describe("table Markdown", () => {
 
     assert.equal(tableRowsToMarkdown(rows), "| A |  |\n| --- | --- |\n| 1 | 2 |")
     assert.deepEqual(rows, [["A"], ["1", "2"]])
+  })
+
+  test("preserves explicit column alignment in Markdown separators", () => {
+    const alignments = ["left", "center", "right", null] as const
+    assert.equal(
+      tableRowsToMarkdown(
+        [
+          ["Name", "Status", "Count", "Note"],
+          ["Quartz", "Ready", "12"],
+        ],
+        alignments,
+      ),
+      "| Name | Status | Count | Note |\n| :--- | :---: | ---: | --- |\n| Quartz | Ready | 12 |  |",
+    )
+    assert.deepEqual(alignments, ["left", "center", "right", null])
+  })
+
+  test("limits alignment metadata to existing columns and defaults missing columns", () => {
+    assert.equal(
+      tableRowsToMarkdown([["A"], ["1", "2"]], ["right"]),
+      "| A |  |\n| ---: | --- |\n| 1 | 2 |",
+    )
+    assert.equal(tableRowsToMarkdown([["A"], ["1"]], [null, "right"]), "| A |\n| --- |\n| 1 |")
+  })
+
+  test("emitted DOM adapter preserves authored header alignment and colspan positions", () => {
+    const cell = (textContent: string, inline = "", attribute = "", colSpan = 1) => ({
+      textContent,
+      tagName: "TH",
+      style: { textAlign: inline },
+      getAttribute: (name: string) => (name === "align" ? attribute : null),
+      colSpan,
+      rowSpan: 1,
+    })
+    const rows = [
+      {
+        cells: [
+          cell("Group", "center", "right", 2),
+          cell("Count", "", "RIGHT"),
+          cell("Note", "justify", "left"),
+        ],
+      },
+      { cells: [cell("A"), cell("B"), cell("12"), cell("C")] },
+    ]
+    const table = { rows: Object.assign(rows, { item: (index: number) => rows[index] }) }
+    const markdown = runInNewContext(`${tableMarkdownScript}\ntableElementToMarkdown(table)`, {
+      document: { addEventListener() {} },
+      table,
+    })
+    assert.equal(
+      markdown,
+      "| Group |  | Count | Note |\n| :---: | :---: | ---: | --- |\n| A | B | 12 | C |",
+    )
   })
 
   test("rejects incomplete tables", () => {

--- a/quartz/components/scripts/tableMarkdown.ts
+++ b/quartz/components/scripts/tableMarkdown.ts
@@ -4,12 +4,15 @@ export type TableMarkdownLabels = Readonly<{
   failed: string
 }>
 
+export type TableColumnAlignment = "left" | "center" | "right" | null
+
 export function normalizeMarkdownTableCell(value: string): string {
   return value.replace(/\s+/gu, " ").trim().replace(/\\/gu, "\\\\").replace(/\|/gu, "\\|")
 }
 
 export function tableRowsToMarkdown(
   rows: ReadonlyArray<ReadonlyArray<string>>,
+  alignments: readonly TableColumnAlignment[] = [],
 ): string | undefined {
   if (rows.length < 2) return
   let columnCount = 0
@@ -25,7 +28,20 @@ export function tableRowsToMarkdown(
     }
     lines.push(`| ${cells.join(" | ")} |`)
     if (rowIndex === 0) {
-      lines.push(`| ${new Array<string>(columnCount).fill("---").join(" | ")} |`)
+      const separators: string[] = []
+      for (let columnIndex = 0; columnIndex < columnCount; columnIndex++) {
+        const alignment = alignments[columnIndex]
+        separators.push(
+          alignment === "left"
+            ? ":---"
+            : alignment === "center"
+              ? ":---:"
+              : alignment === "right"
+                ? "---:"
+                : "---",
+        )
+      }
+      lines.push(`| ${separators.join(" | ")} |`)
     }
   }
 
@@ -53,7 +69,14 @@ export function tableElementToMarkdown(table: HTMLTableElement): string | undefi
     rows.push(values)
   }
 
-  return tableRowsToMarkdown(rows)
+  const alignments: TableColumnAlignment[] = []
+  for (const cell of Array.from(firstRow.cells)) {
+    const value = (cell.style.textAlign || cell.getAttribute("align") || "").trim().toLowerCase()
+    const alignment = value === "left" || value === "center" || value === "right" ? value : null
+    for (let index = 0; index < cell.colSpan; index++) alignments.push(alignment)
+  }
+
+  return tableRowsToMarkdown(rows, alignments)
 }
 
 export function tableMarkdownLabels(dataset: DOMStringMap): TableMarkdownLabels | undefined {


### PR DESCRIPTION
复制表格为 Markdown 现在会保留作者设置的左对齐、居中和右对齐。把数字表格或对照表粘贴回 Obsidian 时，列格式可以直接保留，省去手动补冒号的步骤，也让现有复制按钮更实用。

## 验证

- 表格专项测试 9/9 通过，包括列数边界、跨列表头和实际发出的浏览器脚本。
- TypeScript、变更文件 Prettier、Git diff 检查通过；生产构建处理 314 篇笔记，输出 1,922 个文件。
- Chromium 真实页面在桌面 1280×900 和手机 390×844 验证原生剪贴板写入成功、准确的 Markdown 分隔行、失败反馈与 Enter 重试、重复渲染以及 SPA 首页往返。手机无横向溢出。
- 全量测试 354/356 通过。缺失 jsdom 和首页链接断言这两项失败已在未修改基线上复现。

## 影响范围

仅修改现有表格导出模块和测试。读取表头显式 align 或内联 text-align，不读取主题计算样式。未设置对齐的表格维持原输出，跨列表头保持列位置；不改变依赖、配置、内容或存储。

## 回滚

回退此提交即可恢复全部默认对齐的旧导出行为，无数据迁移。

## 未解决风险

Netlify 预览及三个规则检查失败，GitHub 没有具体代码注解，仅链接到托管部署日志。本地生产构建通过，线上预览仍未确认；本次未改动部署配置。
