### PR TITLE
feat(search): add slash keyboard shortcut

### DIFF
--- a/quartz/components/scripts/searchShortcut.test.ts
+++ b/quartz/components/scripts/searchShortcut.test.ts
@@ -1,0 +1,33 @@
+import { describe, it } from "node:test"
+import assert from "node:assert/strict"
+import { searchShortcutScript, shouldHandleSearchShortcut } from "./searchShortcut"
+
+describe("search shortcut", () => {
+  it("handles slash without modifiers outside editable elements", () => {
+    assert.equal(
+      shouldHandleSearchShortcut({
+        key: "/",
+        target: { tagName: "DIV", isContentEditable: false },
+      }),
+      true,
+    )
+    assert.equal(
+      shouldHandleSearchShortcut({
+        key: "/",
+        target: { tagName: "INPUT", isContentEditable: false },
+      }),
+      false,
+    )
+  })
+
+  it("ignores modifiers and non-slash keys", () => {
+    assert.equal(shouldHandleSearchShortcut({ key: "/", ctrlKey: true }), false)
+    assert.equal(shouldHandleSearchShortcut({ key: "Escape" }), false)
+  })
+
+  it("ships nav lifecycle and escape blur behavior", () => {
+    assert.match(searchShortcutScript, /searchInput\.focus\(\)/)
+    assert.match(searchShortcutScript, /searchInput\.blur\(\)/)
+    assert.match(searchShortcutScript, /document\.addEventListener\("nav", bindSearchShortcut\)/)
+  })
+})

--- a/quartz/components/scripts/searchShortcut.ts
+++ b/quartz/components/scripts/searchShortcut.ts
@@ -1,0 +1,51 @@
+/** Returns true when a keyboard event should trigger the search shortcut. */
+export function shouldHandleSearchShortcut(event: {
+  key: string
+  metaKey?: boolean
+  ctrlKey?: boolean
+  altKey?: boolean
+  shiftKey?: boolean
+  target?: unknown
+}): boolean {
+  if (event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) return false
+  if (event.key !== "/") return false
+  const target = event.target as HTMLElement | null
+  if (!target) return true
+  const tag = target.tagName?.toLowerCase()
+  return tag !== "input" && tag !== "textarea" && tag !== "select" && !target.isContentEditable
+}
+
+export const searchShortcutScript = `
+function isEditableSearchShortcutTarget(target) {
+  if (!target) return false
+  const element = target instanceof HTMLElement ? target : null
+  if (!element) return false
+  const tag = element.tagName.toLowerCase()
+  return tag === "input" || tag === "textarea" || tag === "select" || element.isContentEditable
+}
+
+let cleanupSearchShortcut = () => {}
+
+function bindSearchShortcut() {
+  cleanupSearchShortcut()
+  const handleKeydown = (event) => {
+    if (event.defaultPrevented || event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) return
+    const searchInput = document.querySelector('.search input, input[type="search"]')
+    if (!searchInput) return
+
+    if (event.key === "/" && !isEditableSearchShortcutTarget(event.target)) {
+      event.preventDefault()
+      searchInput.focus()
+    } else if (event.key === "Escape" && document.activeElement === searchInput) {
+      searchInput.blur()
+    }
+  }
+
+  document.addEventListener("keydown", handleKeydown)
+  cleanupSearchShortcut = () => document.removeEventListener("keydown", handleKeydown)
+  window.addCleanup?.(() => cleanupSearchShortcut())
+}
+
+document.addEventListener("nav", bindSearchShortcut)
+bindSearchShortcut()
+`

--- a/quartz/plugins/emitters/componentResources.ts
+++ b/quartz/plugins/emitters/componentResources.ts
@@ -28,6 +28,7 @@ import { localLinkWanderScript } from "../../components/scripts/localLinkWander"
 import localLinkWanderStyle from "../../components/styles/localLinkWander.scss"
 import { wideContentScrollScript } from "../../components/scripts/wideContentScroll"
 import { searchEmptyStateScript } from "../../components/scripts/searchEmptyState"
+import { searchShortcutScript } from "../../components/scripts/searchShortcut"
 import searchFeedbackStyle from "../../components/styles/searchFeedback.scss"
 import wideContentScrollStyle from "../../components/styles/wideContentScroll.scss"
 import { tableMarkdownScript } from "../../components/scripts/tableMarkdown"
@@ -135,6 +136,7 @@ function addGlobalPageResources(ctx: BuildCtx, componentResources: ComponentReso
   componentResources.css.push(localLinkWanderStyle)
   componentResources.afterDOMLoaded.push(wideContentScrollScript)
   componentResources.afterDOMLoaded.push(searchEmptyStateScript)
+  componentResources.afterDOMLoaded.push(searchShortcutScript)
   componentResources.css.push(searchFeedbackStyle)
   componentResources.css.push(wideContentScrollStyle)
   componentResources.afterDOMLoaded.push(tableMarkdownScript)


### PR DESCRIPTION
构建了全站搜索的 `/` 快捷键和 Escape 退出焦点行为。它让熟悉键盘操作的读者可以直接开始查找笔记，减少在长文章和移动布局中寻找搜索入口的摩擦，因此值得合并。

验证：
- focused search shortcut tests 3/3
- `tsc --noEmit`
- scoped Prettier check and `git diff HEAD^ --check`
- production Quartz build passed with 314 Markdown inputs and 1,923 emitted files
- Chromium QA confirmed opening the search overlay and pressing `/` focuses the real search input

影响范围：新增一个全局、无依赖的键盘事件脚本和回归测试，并注册到现有组件资源。搜索索引、排序、导航和输入行为保持不变。

回滚：删除该脚本及其资源注册即可恢复原行为。

已知风险：本地构建保留仓库既有的无效日期和 Google Fonts 400 警告。托管预览状态需由 GitHub/Netlify 后续检查确认。
